### PR TITLE
Remove payer from pack

### DIFF
--- a/tuktuk-cli/src/client.rs
+++ b/tuktuk-cli/src/client.rs
@@ -55,7 +55,7 @@ pub async fn send_instructions(
         .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
         .await
         .expect("Failed to get latest blockhash");
-    let txs = pack_instructions_into_transactions(&[ixs], payer, None)?;
+    let txs = pack_instructions_into_transactions(&[ixs], None)?;
     let mut with_auto_compute: Vec<Message> = Vec::new();
     let keys: Vec<&dyn Signer> = std::iter::once(&payer as &dyn Signer)
         .chain(extra_signers.iter().map(|k| k as &dyn Signer))

--- a/tuktuk-cli/src/cmd/task.rs
+++ b/tuktuk-cli/src/cmd/task.rs
@@ -274,7 +274,6 @@ impl TaskCmd {
                 let ix_groups = ixs.into_iter().map(|ix| vec![ix]).collect_vec();
                 let groups = pack_instructions_into_transactions(
                     &ix_groups.iter().map(|ix| ix.as_slice()).collect_vec(),
-                    &client.payer,
                     None,
                 )?;
 


### PR DESCRIPTION
No need to pass in payer, we can just use Pubkey::default to get transaction lengths for packing