### PR TITLE
fix building websockets url to support more use cases

### DIFF
--- a/tuktuk-crank-turner/src/main.rs
+++ b/tuktuk-crank-turner/src/main.rs
@@ -102,7 +102,7 @@ impl Cli {
         let solana_ws_url = solana_url
             .replace("http", "ws")
             .replace("https", "wss")
-            .replace("127.0.0.1:8899", "127.0.0.1:8900");
+            .replace("8899", "8900");
 
         // Create a non-blocking RPC client
         // We can work off of processed accounts because we simulate the next tx before actually


### PR DESCRIPTION
this change fixes building websockets url from an IP such as http://10.1.1.240:8899 or fqdn such as http://drinkmorewater.com:8899 by removing 127.0.0.1 from the replace call when the crank turner is building the websockets url. previously, it was limited to only being able to run on an rpc, validator, host with local port forwarding to an rpc/validator, or where an instance of nginx handles the routing by protocol such as paid services like helius or shyft.
