### PR TITLE
fix: never propagate outer-transaction signer privilege to tasks

### DIFF
--- a/solana-programs/programs/tuktuk/src/error.rs
+++ b/solana-programs/programs/tuktuk/src/error.rs
@@ -54,4 +54,12 @@ pub enum ErrorCode {
     InvalidAccountKey,
     #[msg("Invalid crank reward")]
     InvalidCrankReward,
+    // Reserved so the follow-up hardening PR can add these without renumbering the codes
+    // above, which clients match on.
+    #[msg("Signer seeds do not resolve to a valid PDA")]
+    InvalidSignerSeeds,
+    #[msg("Instruction references an account index that was not provided")]
+    InvalidAccountIndex,
+    #[msg("Returned tasks account is not owned by the program that returned it")]
+    InvalidTasksAccountOwner,
 }

--- a/solana-programs/programs/tuktuk/src/instructions/queue_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/queue_task_v0.rs
@@ -55,13 +55,14 @@ pub fn handler(ctx: Context<QueueTaskV0>, args: QueueTaskArgsV0) -> Result<()> {
     let mut task_queue = TaskQueueDataWrapper::new(*task_queue_data)?;
 
     // Validate constraints that were removed from the account struct
-    require!(
-        !task_queue.task_exists(args.id),
-        ErrorCode::TaskAlreadyExists
-    );
+    // Range check first -- task_exists indexes the bitmap unchecked.
     require!(
         args.id < task_queue.header().capacity,
         ErrorCode::InvalidTaskId
+    );
+    require!(
+        !task_queue.task_exists(args.id),
+        ErrorCode::TaskAlreadyExists
     );
 
     require_gte!(

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -206,10 +206,11 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         for i in &ix.accounts {
             let acct = remaining_accounts[*i as usize].clone();
             let mut acct = acct.clone();
-            let is_signer = acct.is_signer || self.signer_addresses.contains(&acct.key());
-            if is_signer {
-                acct.is_signer = true;
-            }
+            // A task may only sign for this queue's own `b"custom"` PDAs. Signer privilege is
+            // never inherited from the outer transaction: the crank turner is an arbitrary,
+            // untrusted account, and forwarding its signature would let any task drain it.
+            let is_signer = self.signer_addresses.contains(&acct.key());
+            acct.is_signer = is_signer;
 
             account_infos.push(AccountMeta {
                 pubkey: acct.key(),
@@ -252,8 +253,8 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         )?;
         msg!("Invoked");
 
-        if let Some((_, return_data)) = solana_program::program::get_return_data() {
-            match self.process_return_data(&return_data, &accounts) {
+        if let Some((return_program_id, return_data)) = solana_program::program::get_return_data() {
+            match self.process_return_data(&return_program_id, &return_data, &accounts) {
                 Ok(_) => (),
                 Err(e) => {
                     msg!("Error processing return data: {:?}", e);
@@ -266,6 +267,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
 
     fn process_return_data(
         &mut self,
+        return_program_id: &Pubkey,
         return_data: &[u8],
         accounts: &[AccountInfo<'info>],
     ) -> Result<()> {
@@ -286,13 +288,25 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         }
 
         for account in tasks_accounts {
-            self.process_tasks_account(account)?;
+            self.process_tasks_account(return_program_id, account)?;
         }
 
         Ok(())
     }
 
-    fn process_tasks_account(&mut self, account: &AccountInfo<'info>) -> Result<()> {
+    fn process_tasks_account(
+        &mut self,
+        return_program_id: &Pubkey,
+        account: &AccountInfo<'info>,
+    ) -> Result<()> {
+        // A program may only hand us task lists out of accounts it owns. Without this, a program
+        // could name any account in the instruction and have its raw bytes reinterpreted as tasks.
+        require_keys_eq!(
+            *account.owner,
+            *return_program_id,
+            ErrorCode::InvalidTasksAccountOwner
+        );
+
         let data = account
             .data
             .try_borrow_mut()
@@ -434,7 +448,9 @@ pub fn handler<'info>(
     // Check for duplicate task IDs
     let mut seen_ids = std::collections::HashSet::new();
     for id in args.free_task_ids.clone() {
-        require_gte!(task_queue.header().capacity, id, ErrorCode::InvalidTaskId);
+        // Strictly less than: id == capacity indexes one byte past the bitmap, which lands on
+        // the name length prefix and shifts every offset the wrapper parses after it.
+        require_gt!(task_queue.header().capacity, id, ErrorCode::InvalidTaskId);
         // Ensure ID is not already in use in the task queue
         require!(!task_queue.task_exists(id), ErrorCode::TaskIdAlreadyInUse);
         // Check for duplicates in provided IDs

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -172,6 +172,82 @@ describe("tuktuk", () => {
       expect(taskAcc.crankReward.toString()).to.eq(crankReward.toString());
     });
 
+    it("does not let a task borrow the crank turner's signature", async () => {
+      const crankTurner = Keypair.generate();
+      const attacker = Keypair.generate();
+      const stolen = 500000000;
+      await sendInstructions(provider, [
+        SystemProgram.transfer({
+          fromPubkey: me,
+          toPubkey: crankTurner.publicKey,
+          lamports: 2000000000,
+        }),
+      ]);
+
+      // A task whose compiled transaction drains whoever cranks it.
+      const { transaction: drainTx, remainingAccounts: drainAccounts } =
+        await compileTransaction(
+          [
+            SystemProgram.transfer({
+              fromPubkey: crankTurner.publicKey,
+              toPubkey: attacker.publicKey,
+              lamports: stolen,
+            }),
+          ],
+          []
+        );
+
+      const task = taskKey(taskQueue, 1)[0];
+      await program.methods
+        .queueTaskV0({
+          id: 1,
+          trigger: { now: {} },
+          transaction: { compiledV0: [drainTx] },
+          crankReward: null,
+          freeTasks: 0,
+          description: "drain",
+        })
+        .remainingAccounts(drainAccounts)
+        .accounts({ payer: me, taskQueue, task })
+        .rpc();
+
+      const balanceBefore = await provider.connection.getBalance(
+        crankTurner.publicKey
+      );
+
+      const ixs = await runTask({
+        program,
+        task,
+        crankTurner: crankTurner.publicKey,
+      });
+      const tx = toVersionedTx(
+        await populateMissingDraftInfo(provider.connection, {
+          feePayer: crankTurner.publicKey,
+          instructions: ixs,
+        })
+      );
+      await tx.sign([crankTurner]);
+
+      let failed = false;
+      try {
+        await sendAndConfirmWithRetry(
+          provider.connection,
+          Buffer.from(tx.serialize()),
+          { skipPreflight: true, maxRetries: 0 },
+          "confirmed"
+        );
+      } catch (e) {
+        failed = true;
+      }
+      expect(failed).to.be.true;
+
+      const balanceAfter = await provider.connection.getBalance(
+        crankTurner.publicKey
+      );
+      expect(balanceBefore - balanceAfter).to.be.lessThan(stolen);
+      expect(await provider.connection.getBalance(attacker.publicKey)).to.eq(0);
+    });
+
     it("allows closing a task queue", async () => {
       await program.methods
         .removeQueueAuthorityV0()
@@ -234,7 +310,7 @@ describe("tuktuk", () => {
 
       it("allows running a task", async () => {
         const taskAcc = await program.account.taskV0.fetch(task);
-        
+
         const ixs = await runTask({
           program,
           task,
@@ -256,10 +332,7 @@ describe("tuktuk", () => {
               remoteTaskTransaction: serialized,
               remainingAccounts: remainingAccounts,
               signature: Buffer.from(
-                sign.detached(
-                  Uint8Array.from(serialized),
-                  signer.secretKey
-                )
+                sign.detached(Uint8Array.from(serialized), signer.secretKey)
               ),
             };
           },
@@ -364,13 +437,15 @@ describe("tuktuk", () => {
 
         // Calculate expected balance change
         const expectedBalanceChange = expectedReward - txFee;
-        const actualBalanceChange = crankTurnerBalanceAfter - crankTurnerBalanceBefore;
+        const actualBalanceChange =
+          crankTurnerBalanceAfter - crankTurnerBalanceBefore;
 
-        expect(actualBalanceChange).to.equal(expectedBalanceChange, 
+        expect(actualBalanceChange).to.equal(
+          expectedBalanceChange,
           `Crank turner balance change incorrect. Expected change: ${expectedBalanceChange}, ` +
-          `Actual change: ${actualBalanceChange}, ` +
-          `Reward: ${expectedReward}, ` +
-          `TX fee: ${txFee}`
+            `Actual change: ${actualBalanceChange}, ` +
+            `Reward: ${expectedReward}, ` +
+            `TX fee: ${txFee}`
         );
       });
 
@@ -435,14 +510,14 @@ describe("tuktuk", () => {
           taskQueueNameMapping: taskQueueNameMappingKey(tuktukConfig, name)[0],
         })
         .rpc();
-        await program.methods
-          .addQueueAuthorityV0()
-          .accounts({
-            payer: me,
-            queueAuthority,
-            taskQueue,
-          })
-          .rpc();
+      await program.methods
+        .addQueueAuthorityV0()
+        .accounts({
+          payer: me,
+          queueAuthority,
+          taskQueue,
+        })
+        .rpc();
     });
     it("allows scheduling a task", async () => {
       const freeTask1 = taskKey(taskQueue, 0)[0];


### PR DESCRIPTION
A task may only sign for its own queue's `b"custom"` PDAs. Previously `is_signer` was inherited from the outer transaction, so any task could name the crank turner (or any other signer of the enclosing transaction) as a signer of its inner instructions and drain it.

Also in this hotfix, both loss-of-funds adjacent:

- Require returned task-list accounts to be owned by the program that returned them. Without this a program could name any account in the instruction and have its raw bytes reinterpreted as tasks, minting tasks with an arbitrary crank_reward.
- Range-check task ids strictly against capacity. `id == capacity` indexes one byte past the bitmap onto the name length prefix, shifting every offset the wrapper parses after it. In queue_task_v0 the range check has to run before task_exists, which indexes unchecked.

Three error variants are added together so the follow-up hardening PR does not renumber codes that clients match on.