### PR TITLE
chore: release tuktuk-sdk 0.4.1 and npm packages 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6903,7 +6903,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anchor-lang",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ spl-token = "4.0.0"
 itertools = "0.13"
 tokio-graceful-shutdown = "0.15"
 solana-transaction-utils = { version = "0.4.2", path = "./solana-transaction-utils" }
-tuktuk-sdk = { version = "0.4.0", path = "./tuktuk-sdk" }
+tuktuk-sdk = { version = "0.4.1", path = "./tuktuk-sdk" }
 tuktuk-program = { version = "0.3.2", path = "./tuktuk-program" }
 solana-account-decoder = { version = "2.2.3" }
 solana-clock = { version = "2.2.1" }

--- a/solana-programs/CHANGELOG.md
+++ b/solana-programs/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.11 (2026-08-03)
+
+
+### Bug Fixes
+
+* address code review findings ([2bcb205](https://github.com/helium/tuktuk/commit/2bcb2053d3504527eef9cc4aa8739b95e64af7d7))
+* never propagate outer-transaction signer privilege to tasks ([7c9e6fb](https://github.com/helium/tuktuk/commit/7c9e6fb780579732284561fee7f4cbcc8fd9c754))
+* never propagate outer-transaction signer privilege to tasks ([9c384ed](https://github.com/helium/tuktuk/commit/9c384edddfc305e0e89f32861693d40504a0d51e))
+* pin solana-verify to 0.4.11 for rustc 1.82 compatibility ([1824a9b](https://github.com/helium/tuktuk/commit/1824a9bb6b9102a3c97fe769c57b820bf974901b))
+* remove useless into_iter call flagged by stable clippy ([e97a807](https://github.com/helium/tuktuk/commit/e97a80706642ee287b64a6e89429e83be1d4f9bf))
+* remove useless into_iter calls flagged by clippy ([ec8a21d](https://github.com/helium/tuktuk/commit/ec8a21d391ffe9697e89cebfd60506b4b39de378))
+
+
+### Features
+
+* Allow remote servers to return additional LUTs ([#80](https://github.com/helium/tuktuk/issues/80)) ([6202c89](https://github.com/helium/tuktuk/commit/6202c89262e171e6c556ef231d28f5f47832e366))
+
+
+
+
+
 ## 0.0.10 (2025-11-17)
 
 **Note:** Version bump only for package solana-programs

--- a/solana-programs/lerna.json
+++ b/solana-programs/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "0.0.10"
+  "version": "0.0.11"
 }

--- a/solana-programs/packages/cron-sdk/CHANGELOG.md
+++ b/solana-programs/packages/cron-sdk/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.11 (2026-08-03)
+
+**Note:** Version bump only for package @helium/cron-sdk
+
+
+
+
+
 ## 0.0.10 (2025-11-17)
 
 **Note:** Version bump only for package @helium/cron-sdk

--- a/solana-programs/packages/cron-sdk/package.json
+++ b/solana-programs/packages/cron-sdk/package.json
@@ -5,7 +5,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "license": "Apache-2.0",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Interface to the cron smart contract",
   "repository": {
     "type": "git",
@@ -33,8 +33,8 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0",
     "@helium/anchor-resolvers": "^0.10.0-alpha.4",
-    "@helium/tuktuk-idls": "^0.0.10",
-    "@helium/tuktuk-sdk": "^0.0.10",
+    "@helium/tuktuk-idls": "^0.0.11",
+    "@helium/tuktuk-sdk": "^0.0.11",
     "js-sha256": "^0.11.0"
   },
   "devDependencies": {

--- a/solana-programs/packages/remote-example-server/CHANGELOG.md
+++ b/solana-programs/packages/remote-example-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.11 (2026-08-03)
+
+**Note:** Version bump only for package @helium/faucet-service
+
+
+
+
+
 ## 0.0.10 (2025-11-17)
 
 **Note:** Version bump only for package @helium/faucet-service

--- a/solana-programs/packages/remote-example-server/package.json
+++ b/solana-programs/packages/remote-example-server/package.json
@@ -6,7 +6,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "license": "Apache-2.0",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Remote example server for Tuktuk",
   "repository": {
     "type": "git",
@@ -36,8 +36,8 @@
     "@coral-xyz/anchor": "^0.31.0",
     "@fastify/cors": "^8.1.1",
     "@helium/spl-utils": "^0.10.3",
-    "@helium/tuktuk-idls": "^0.0.10",
-    "@helium/tuktuk-sdk": "^0.0.10",
+    "@helium/tuktuk-idls": "^0.0.11",
+    "@helium/tuktuk-sdk": "^0.0.11",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.95.2",
     "bn.js": "^5.2.0",

--- a/solana-programs/packages/tuktuk-idls/CHANGELOG.md
+++ b/solana-programs/packages/tuktuk-idls/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.11 (2026-08-03)
+
+**Note:** Version bump only for package @helium/tuktuk-idls
+
+
+
+
+
 ## 0.0.10 (2025-11-17)
 
 **Note:** Version bump only for package @helium/tuktuk-idls

--- a/solana-programs/packages/tuktuk-idls/package.json
+++ b/solana-programs/packages/tuktuk-idls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/tuktuk-idls",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Exported idls",
   "publishConfig": {
     "access": "public",

--- a/solana-programs/packages/tuktuk-sdk/CHANGELOG.md
+++ b/solana-programs/packages/tuktuk-sdk/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 0.0.11 (2026-08-03)
+
+
+### Bug Fixes
+
+* address code review findings ([2bcb205](https://github.com/helium/tuktuk/commit/2bcb2053d3504527eef9cc4aa8739b95e64af7d7))
+* never propagate outer-transaction signer privilege to tasks ([9c384ed](https://github.com/helium/tuktuk/commit/9c384edddfc305e0e89f32861693d40504a0d51e))
+
+
+
+
+
 ## 0.0.10 (2025-11-17)
 
 **Note:** Version bump only for package @helium/tuktuk-sdk

--- a/solana-programs/packages/tuktuk-sdk/package.json
+++ b/solana-programs/packages/tuktuk-sdk/package.json
@@ -5,7 +5,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "license": "Apache-2.0",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Interface to the tuktuk smart contract",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0",
     "@helium/anchor-resolvers": "^0.10.0-alpha.4",
-    "@helium/tuktuk-idls": "^0.0.10",
+    "@helium/tuktuk-idls": "^0.0.11",
     "js-sha256": "^0.11.0"
   },
   "devDependencies": {

--- a/tuktuk-sdk/Cargo.toml
+++ b/tuktuk-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-sdk"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Version bumps for releasing the fetcher signer sanitization fix (#85):

- `tuktuk-sdk` 0.4.0 → 0.4.1 (workspace pin updated to match)
- npm packages 0.0.10 → 0.0.11 via lerna

## Release steps after merge

1. `cargo publish -p tuktuk-sdk` then tag `tuktuk-sdk-v0.4.1`
2. `cargo publish -p tuktuk-crank-turner` (already at 0.2.27) then tag `tuktuk-crank-turner-v0.2.27`
3. Tag `v0.0.11` on main to trigger the NPM Publish workflow