### PR TITLE
Bound returned-task crank reward and enforce declared free_tasks

### DIFF
--- a/solana-programs/Cargo.lock
+++ b/solana-programs/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana-programs/programs/cpi-example/src/lib.rs
+++ b/solana-programs/programs/cpi-example/src/lib.rs
@@ -1,7 +1,57 @@
-use anchor_lang::prelude::*;
-use tuktuk_program::tuktuk::program::Tuktuk;
+use anchor_lang::{
+    prelude::*, solana_program::instruction::Instruction as SolanaInstruction, InstructionData,
+};
+use tuktuk_program::{
+    compile_transaction, tuktuk::program::Tuktuk, tuktuk::types::TriggerV0 as TuktukTrigger,
+    TaskReturnV0 as TuktukTaskReturn, TransactionSourceV0 as TuktukTransactionSource,
+};
 
 declare_id!("cpic9j9sjqvhn2ZX3mqcCgzHKCwiiBTyEszyCwN7MBC");
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Default)]
+pub struct ScheduleReturningArgsV0 {
+    pub task_id: u16,
+    /// Spawn budget the queued task declares.
+    pub free_tasks: u8,
+    /// Reward carried by the child task it returns.
+    pub return_crank_reward: Option<u64>,
+    /// Spawn budget carried by the child task it returns.
+    pub return_free_tasks: u8,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Default)]
+pub struct ReturnTaskArgsV0 {
+    pub crank_reward: Option<u64>,
+    pub free_tasks: u8,
+}
+
+/// Builds a terminal child task carrying the caller's chosen reward and spawn budget.
+fn noop_task_return(
+    system_program: &Program<System>,
+    args: &ReturnTaskArgsV0,
+) -> Result<TuktukTaskReturn> {
+    let (compiled_tx, _) = compile_transaction(
+        vec![SolanaInstruction {
+            program_id: crate::ID,
+            accounts: crate::__cpi_client_accounts_recurring_task::RecurringTask {
+                system_program: system_program.to_account_info(),
+            }
+            .to_account_metas(None)
+            .to_vec(),
+            data: crate::instruction::NoopTask.data(),
+        }],
+        vec![],
+    )
+    .unwrap();
+
+    Ok(TuktukTaskReturn {
+        trigger: TuktukTrigger::Now,
+        transaction: TuktukTransactionSource::CompiledV0(compiled_tx),
+        crank_reward: args.crank_reward,
+        free_tasks: args.free_tasks,
+        description: "test".to_string(),
+    })
+}
 
 #[program]
 pub mod cpi_example {
@@ -109,6 +159,161 @@ pub mod cpi_example {
         )?;
 
         Ok(())
+    }
+
+    /// Queues a task that declares `free_tasks` and, when run, returns a single child task
+    /// built from `return_crank_reward` / `return_free_tasks`. Lets a test drive the bounds
+    /// a returned task is held to.
+    pub fn schedule_returning(ctx: Context<Schedule>, args: ScheduleReturningArgsV0) -> Result<()> {
+        let (compiled_tx, _) = compile_transaction(
+            vec![Instruction {
+                program_id: crate::ID,
+                accounts: crate::__cpi_client_accounts_recurring_task::RecurringTask {
+                    system_program: ctx.accounts.system_program.to_account_info(),
+                }
+                .to_account_metas(None)
+                .to_vec(),
+                data: crate::instruction::ReturnTask {
+                    args: ReturnTaskArgsV0 {
+                        crank_reward: args.return_crank_reward,
+                        free_tasks: args.return_free_tasks,
+                    },
+                }
+                .data(),
+            }],
+            vec![],
+        )
+        .unwrap();
+
+        queue_task_v0(
+            CpiContext::new_with_signer(
+                ctx.accounts.tuktuk_program.to_account_info(),
+                QueueTaskV0 {
+                    payer: ctx.accounts.queue_authority.to_account_info(),
+                    queue_authority: ctx.accounts.queue_authority.to_account_info(),
+                    task_queue: ctx.accounts.task_queue.to_account_info(),
+                    task_queue_authority: ctx.accounts.task_queue_authority.to_account_info(),
+                    task: ctx.accounts.task.to_account_info(),
+                    system_program: ctx.accounts.system_program.to_account_info(),
+                },
+                &[&["queue_authority".as_bytes(), &[ctx.bumps.queue_authority]]],
+            ),
+            QueueTaskArgsV0 {
+                trigger: TriggerV0::Now,
+                transaction: TransactionSourceV0::CompiledV0(compiled_tx),
+                crank_reward: None,
+                free_tasks: args.free_tasks,
+                id: args.task_id,
+                description: "test".to_string(),
+            },
+        )?;
+
+        Ok(())
+    }
+
+    /// Returns a single child task with a caller-chosen reward and spawn budget, via return data.
+    pub fn return_task(
+        ctx: Context<RecurringTask>,
+        args: ReturnTaskArgsV0,
+    ) -> Result<tuktuk_program::RunTaskReturnV0> {
+        Ok(RunTaskReturnV0 {
+            tasks: vec![noop_task_return(&ctx.accounts.system_program, &args)?],
+            accounts: vec![],
+        })
+    }
+
+    /// Terminal task: returns nothing, so a test's assertions are not disturbed by further
+    /// rescheduling.
+    pub fn noop_task(_ctx: Context<RecurringTask>) -> Result<tuktuk_program::RunTaskReturnV0> {
+        Ok(RunTaskReturnV0 {
+            tasks: vec![],
+            accounts: vec![],
+        })
+    }
+
+    /// As `schedule_returning`, but the child task is handed back in an account rather than in
+    /// return data, which is the other path that creates returned tasks.
+    pub fn schedule_returning_via_account(
+        ctx: Context<ScheduleWithAccountReturn>,
+        args: ScheduleReturningArgsV0,
+    ) -> Result<()> {
+        let (compiled_tx, _) = compile_transaction(
+            vec![Instruction {
+                program_id: crate::ID,
+                accounts:
+                    crate::__client_accounts_recurring_task_with_account_return::RecurringTaskWithAccountReturn {
+                        system_program: ctx.accounts.system_program.key(),
+                        queue_authority: ctx.accounts.queue_authority.key(),
+                        task_return_account: ctx.accounts.task_return_account.key(),
+                    }
+                    .to_account_metas(None)
+                    .to_vec(),
+                data: crate::instruction::ReturnTaskViaAccount {
+                    args: ReturnTaskArgsV0 {
+                        crank_reward: args.return_crank_reward,
+                        free_tasks: args.return_free_tasks,
+                    },
+                }
+                .data(),
+            }],
+            vec![],
+        )
+        .unwrap();
+
+        queue_task_v0(
+            CpiContext::new_with_signer(
+                ctx.accounts.tuktuk_program.to_account_info(),
+                QueueTaskV0 {
+                    payer: ctx.accounts.queue_authority.to_account_info(),
+                    queue_authority: ctx.accounts.queue_authority.to_account_info(),
+                    task_queue: ctx.accounts.task_queue.to_account_info(),
+                    task_queue_authority: ctx.accounts.task_queue_authority.to_account_info(),
+                    task: ctx.accounts.task.to_account_info(),
+                    system_program: ctx.accounts.system_program.to_account_info(),
+                },
+                &[&["queue_authority".as_bytes(), &[ctx.bumps.queue_authority]]],
+            ),
+            QueueTaskArgsV0 {
+                trigger: TriggerV0::Now,
+                transaction: TransactionSourceV0::CompiledV0(compiled_tx),
+                crank_reward: None,
+                free_tasks: args.free_tasks,
+                id: args.task_id,
+                description: "test".to_string(),
+            },
+        )?;
+
+        Ok(())
+    }
+
+    /// Returns a single child task with a caller-chosen reward and spawn budget, via an account.
+    pub fn return_task_via_account(
+        ctx: Context<RecurringTaskWithAccountReturn>,
+        args: ReturnTaskArgsV0,
+    ) -> Result<tuktuk_program::RunTaskReturnV0> {
+        let task = noop_task_return(&ctx.accounts.system_program, &args)?;
+        let return_accounts = write_return_tasks(WriteReturnTasksArgs {
+            program_id: crate::ID,
+            payer_info: PayerInfo::SystemPayer {
+                account_info: ctx.accounts.queue_authority.to_account_info(),
+                seeds: vec![b"queue_authority".to_vec(), vec![ctx.bumps.queue_authority]],
+            },
+            accounts: vec![AccountWithSeeds {
+                account: ctx.accounts.task_return_account.to_account_info(),
+                seeds: vec![
+                    b"task_return_account".to_vec(),
+                    vec![ctx.bumps.task_return_account],
+                ],
+            }],
+            system_program: ctx.accounts.system_program.to_account_info(),
+            tasks: std::iter::once(task),
+        })?
+        .used_accounts;
+
+        Ok(RunTaskReturnV0 {
+            tasks: vec![],
+            accounts: return_accounts,
+        })
     }
 
     pub fn recurring_task(ctx: Context<RecurringTask>) -> Result<tuktuk_program::RunTaskReturnV0> {

--- a/solana-programs/programs/cpi-example/src/lib.rs
+++ b/solana-programs/programs/cpi-example/src/lib.rs
@@ -15,14 +15,11 @@ pub struct ScheduleReturningArgsV0 {
     pub free_tasks: u8,
     /// Reward carried by the child task it returns.
     pub return_crank_reward: Option<u64>,
-    /// Spawn budget carried by the child task it returns.
-    pub return_free_tasks: u8,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Default)]
 pub struct ReturnTaskArgsV0 {
     pub crank_reward: Option<u64>,
-    pub free_tasks: u8,
 }
 
 /// Builds a terminal child task carrying the caller's chosen reward and spawn budget.
@@ -48,7 +45,8 @@ fn noop_task_return(
         trigger: TuktukTrigger::Now,
         transaction: TuktukTransactionSource::CompiledV0(compiled_tx),
         crank_reward: args.crank_reward,
-        free_tasks: args.free_tasks,
+        // Terminal: the child spawns nothing.
+        free_tasks: 0,
         description: "test".to_string(),
     })
 }
@@ -176,7 +174,6 @@ pub mod cpi_example {
                 data: crate::instruction::ReturnTask {
                     args: ReturnTaskArgsV0 {
                         crank_reward: args.return_crank_reward,
-                        free_tasks: args.return_free_tasks,
                     },
                 }
                 .data(),
@@ -251,7 +248,6 @@ pub mod cpi_example {
                 data: crate::instruction::ReturnTaskViaAccount {
                     args: ReturnTaskArgsV0 {
                         crank_reward: args.return_crank_reward,
-                        free_tasks: args.return_free_tasks,
                     },
                 }
                 .data(),

--- a/solana-programs/programs/tuktuk/Cargo.toml
+++ b/solana-programs/programs/tuktuk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk"
-version = "0.2.6"
+version = "0.2.7"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana-programs/programs/tuktuk/src/error.rs
+++ b/solana-programs/programs/tuktuk/src/error.rs
@@ -62,4 +62,6 @@ pub enum ErrorCode {
     InvalidAccountIndex,
     #[msg("Returned tasks account is not owned by the program that returned it")]
     InvalidTasksAccountOwner,
+    #[msg("Returned task crank reward exceeds the task queue's min crank reward")]
+    CrankRewardExceedsMax,
 }

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -146,11 +146,12 @@ struct TaskProcessor<'a, 'info> {
     // Changes to make to task queue
     tasks_to_set: Vec<u16>, // Task IDs to set as existing
     queue_lamports_needed: u64,
-    // Set when a returned task found no free task id left to take. Errors raised while
-    // processing return data are swallowed, so this is carried out to `handler` and failed
-    // there: the crank turner chooses how many ids to supply, and a task's children must not
-    // be droppable by supplying too few.
-    out_of_free_task_ids: bool,
+    // Set when a returned task could not be created because of the free-task id or account the
+    // crank turner supplied. Errors raised while processing return data are swallowed, so this
+    // is carried out to `handler` and failed there. The turner picks both, and a task's children
+    // must not be droppable by picking them badly; a reward or description the returning program
+    // chose is that program's fault and is still dropped silently.
+    bad_free_task_input: bool,
 }
 
 impl<'a, 'info> TaskProcessor<'a, 'info> {
@@ -195,7 +196,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             capacity,
             tasks_to_set: Vec::new(),
             queue_lamports_needed: 0,
-            out_of_free_task_ids: false,
+            bad_free_task_input: false,
         })
     }
 
@@ -360,7 +361,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         let task_id = match self.free_task_ids.pop() {
             Some(id) => id,
             None => {
-                self.out_of_free_task_ids = true;
+                self.bad_free_task_input = true;
                 return Err(error!(ErrorCode::TooManyReturnedTasks));
             }
         };
@@ -370,14 +371,17 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         let task_queue_key = self.ctx.accounts.task_queue.key();
 
         // Verify the account is empty
-        require!(
-            free_task_account.data_is_empty(),
-            ErrorCode::FreeTaskAccountNotEmpty
-        );
+        if !free_task_account.data_is_empty() {
+            self.bad_free_task_input = true;
+            return Err(error!(ErrorCode::FreeTaskAccountNotEmpty));
+        }
 
         let seeds = [b"task", task_queue_key.as_ref(), &task_id.to_le_bytes()];
         let (key, bump_seed) = Pubkey::find_program_address(&seeds, self.ctx.program_id);
-        require_eq!(key, free_task_account.key(), ErrorCode::InvalidTaskPDA);
+        if key != free_task_account.key() {
+            self.bad_free_task_input = true;
+            return Err(error!(ErrorCode::InvalidTaskPDA));
+        }
 
         let mut task_data = TaskV0 {
             description: task.description,
@@ -439,8 +443,8 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         task_data.try_serialize(&mut data.as_mut())
     }
 
-    fn ran_out_of_free_task_ids(&self) -> bool {
-        self.out_of_free_task_ids
+    fn had_bad_free_task_input(&self) -> bool {
+        self.bad_free_task_input
     }
 
     fn get_tasks_to_set(&self) -> &[u16] {
@@ -625,10 +629,10 @@ pub fn handler<'info>(
             processor.process_instruction(ix, remaining_accounts)?;
         }
 
-        // A returned task that found no id left is not a task the turner may simply drop.
+        // A child that failed on the turner's own id or account choice is not one they may drop.
         require!(
-            !processor.ran_out_of_free_task_ids(),
-            ErrorCode::TooManyReturnedTasks
+            !processor.had_bad_free_task_input(),
+            ErrorCode::InvalidTaskPDA
         );
 
         // Get the changes we need to make

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -146,6 +146,11 @@ struct TaskProcessor<'a, 'info> {
     // Changes to make to task queue
     tasks_to_set: Vec<u16>, // Task IDs to set as existing
     queue_lamports_needed: u64,
+    // Set when a returned task found no free task id left to take. Errors raised while
+    // processing return data are swallowed, so this is carried out to `handler` and failed
+    // there: the crank turner chooses how many ids to supply, and a task's children must not
+    // be droppable by supplying too few.
+    out_of_free_task_ids: bool,
 }
 
 impl<'a, 'info> TaskProcessor<'a, 'info> {
@@ -190,6 +195,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             capacity,
             tasks_to_set: Vec::new(),
             queue_lamports_needed: 0,
+            out_of_free_task_ids: false,
         })
     }
 
@@ -333,10 +339,10 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             self.min_crank_reward,
             ErrorCode::InvalidCrankReward
         );
-        // A returned task is funded by the task queue, so `min_crank_reward` is its ceiling as well
-        // as its floor. `queue_task_v0` is uncapped because the payer funds that reward from their
-        // own account. Errors here are swallowed by the return-data handler: the task is not
-        // created, but the transaction still succeeds.
+        // A returned task is funded by the task queue, so `min_crank_reward` is its ceiling as
+        // well as its floor: together with the check above, a returned reward is either `None` or
+        // exactly `min_crank_reward`. Errors here are swallowed by the return-data handler, so the
+        // task is not created but the transaction still succeeds.
         require_gte!(
             self.min_crank_reward,
             task.crank_reward.unwrap_or(self.min_crank_reward),
@@ -351,10 +357,13 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         // Take the id before the account. Ids and free-task accounts are consumed one per created
         // task and their counts are equal, so an exhausted id list is what says there is no
         // account left to take either.
-        let task_id = self
-            .free_task_ids
-            .pop()
-            .ok_or(error!(ErrorCode::TooManyReturnedTasks))?;
+        let task_id = match self.free_task_ids.pop() {
+            Some(id) => id,
+            None => {
+                self.out_of_free_task_ids = true;
+                return Err(error!(ErrorCode::TooManyReturnedTasks));
+            }
+        };
 
         let free_task_account = &self.ctx.remaining_accounts[self.free_task_index];
         self.free_task_index += 1;
@@ -428,6 +437,10 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
 
         let mut data = free_task_account.try_borrow_mut_data()?;
         task_data.try_serialize(&mut data.as_mut())
+    }
+
+    fn ran_out_of_free_task_ids(&self) -> bool {
+        self.out_of_free_task_ids
     }
 
     fn get_tasks_to_set(&self) -> &[u16] {
@@ -511,6 +524,14 @@ pub fn handler<'info>(
                 .max()
                 .unwrap()
                 + 1;
+
+            // The crank turner chooses how many accounts to pass, and the slice below indexes
+            // this many of them.
+            require_gte!(
+                remaining_accounts.len(),
+                num_accounts as usize,
+                ErrorCode::MismatchedFreeTaskCounts
+            );
 
             let verification_hash = hash(
                 &[
@@ -603,6 +624,12 @@ pub fn handler<'info>(
         for ix in &transaction.instructions {
             processor.process_instruction(ix, remaining_accounts)?;
         }
+
+        // A returned task that found no id left is not a task the turner may simply drop.
+        require!(
+            !processor.ran_out_of_free_task_ids(),
+            ErrorCode::TooManyReturnedTasks
+        );
 
         // Get the changes we need to make
         let tasks_to_set = processor.get_tasks_to_set().to_vec();

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -344,7 +344,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         );
         require_gte!(
             self.capacity,
-            (task.free_tasks + 1) as u16,
+            task.free_tasks as u16 + 1,
             ErrorCode::FreeTasksGreaterThanCapacity
         );
 

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -333,6 +333,15 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             self.min_crank_reward,
             ErrorCode::InvalidCrankReward
         );
+        // A returned task is funded by the task queue, so `min_crank_reward` is its ceiling as well
+        // as its floor. `queue_task_v0` is uncapped because the payer funds that reward from their
+        // own account. Errors here are swallowed by the return-data handler: the task is not
+        // created, but the transaction still succeeds.
+        require_gte!(
+            self.min_crank_reward,
+            task.crank_reward.unwrap_or(self.min_crank_reward),
+            ErrorCode::CrankRewardExceedsMax
+        );
         require_gte!(
             self.capacity,
             (task.free_tasks + 1) as u16,
@@ -445,6 +454,14 @@ pub fn handler<'info>(
 
     task_queue.header_mut().updated_at = now;
 
+    // A task may spawn no more children than it declared when it was queued. `free_task_ids` is
+    // supplied by the crank turner, so the task's own declaration is the authoritative bound.
+    require_gte!(
+        ctx.accounts.task.free_tasks as usize,
+        args.free_task_ids.len(),
+        ErrorCode::TooManyReturnedTasks
+    );
+
     // Check for duplicate task IDs
     let mut seen_ids = std::collections::HashSet::new();
     for id in args.free_task_ids.clone() {
@@ -545,10 +562,12 @@ pub fn handler<'info>(
 
     // Validate that all free task accounts are empty and are valid PDAs
     let free_tasks_start_index = transaction.accounts.len();
-    // Validate number of free task accounts matches number of task IDs
+    // Validate number of free task accounts matches number of task IDs. Stated as a sum rather
+    // than a difference: the crank turner chooses how many accounts to pass, and too few would
+    // underflow the subtraction.
     require_eq!(
-        args.free_task_ids.len(),
-        ctx.remaining_accounts.len() - free_tasks_start_index,
+        ctx.remaining_accounts.len(),
+        free_tasks_start_index + args.free_task_ids.len(),
         ErrorCode::MismatchedFreeTaskCounts
     );
 

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -348,14 +348,17 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             ErrorCode::FreeTasksGreaterThanCapacity
         );
 
-        let free_task_account = &self.ctx.remaining_accounts[self.free_task_index];
-        self.free_task_index += 1;
-        let task_queue_key = self.ctx.accounts.task_queue.key();
-
+        // Take the id before the account. Ids and free-task accounts are consumed one per created
+        // task and their counts are equal, so an exhausted id list is what says there is no
+        // account left to take either.
         let task_id = self
             .free_task_ids
             .pop()
             .ok_or(error!(ErrorCode::TooManyReturnedTasks))?;
+
+        let free_task_account = &self.ctx.remaining_accounts[self.free_task_index];
+        self.free_task_index += 1;
+        let task_queue_key = self.ctx.accounts.task_queue.key();
 
         // Verify the account is empty
         require!(

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -172,6 +172,110 @@ describe("tuktuk", () => {
       expect(taskAcc.crankReward.toString()).to.eq(crankReward.toString());
     });
 
+    // The compiled-transaction account list a crank turner passes to runTaskV0, with the
+    // writability the program recomputes from the compiled header.
+    function taskAccounts(): AccountMeta[] {
+      const { numRwSigners, numRoSigners, numRw } = transaction;
+      return remainingAccounts.map((acc, index) => ({
+        pubkey: acc.pubkey,
+        isWritable:
+          index < numRwSigners ||
+          (index >= numRwSigners + numRoSigners &&
+            index < numRwSigners + numRoSigners + numRw),
+        isSigner: false,
+      }));
+    }
+
+    async function queueTask(id: number, freeTasks: number) {
+      const task = taskKey(taskQueue, id)[0];
+      await program.methods
+        .queueTaskV0({
+          id,
+          trigger: { now: {} },
+          transaction: { compiledV0: [transaction] },
+          crankReward: null,
+          freeTasks,
+          description: "test",
+        })
+        .remainingAccounts(remainingAccounts)
+        .accounts({ payer: me, taskQueue, task })
+        .rpc();
+      return task;
+    }
+
+    function runTaskWithIds(task: PublicKey, freeTaskIds: number[]) {
+      return program.methods
+        .runTaskV0({ freeTaskIds })
+        .accounts({ task, crankTurner: me })
+        .remainingAccounts([
+          ...taskAccounts(),
+          ...freeTaskIds.map((id) => ({
+            pubkey: taskKey(taskQueue, id)[0],
+            isWritable: true,
+            isSigner: false,
+          })),
+        ])
+        .rpc();
+    }
+
+    it("rejects more free task ids than the task declared", async () => {
+      const task = await queueTask(2, 0);
+
+      let code: string | undefined;
+      try {
+        await runTaskWithIds(task, [100]);
+      } catch (e: any) {
+        code = e?.error?.errorCode?.code ?? JSON.stringify(e);
+      }
+      expect(code).to.eq("TooManyReturnedTasks");
+    });
+
+    it("accepts exactly as many free task ids as the task declared", async () => {
+      const task = await queueTask(3, 6);
+
+      await runTaskWithIds(task, [100, 101, 102, 103, 104, 105]);
+
+      // The task ran to completion and closed itself out.
+      expect(await program.account.taskV0.fetchNullable(task)).to.be.null;
+    });
+
+    it("rejects fewer accounts than the task's transaction needs", async () => {
+      const task = await queueTask(5, 0);
+
+      let code: string | undefined;
+      try {
+        // One short of the compiled transaction's own account list, with no free tasks.
+        await program.methods
+          .runTaskV0({ freeTaskIds: [] })
+          .accounts({ task, crankTurner: me })
+          .remainingAccounts(taskAccounts().slice(0, -1))
+          .rpc();
+      } catch (e: any) {
+        code = e?.error?.errorCode?.code ?? JSON.stringify(e);
+      }
+      expect(code).to.eq("MismatchedFreeTaskCounts");
+    });
+
+    it("allows a payer funded task above the queue minimum reward", async () => {
+      const task = taskKey(taskQueue, 4)[0];
+      const aboveMin = crankReward.muln(2);
+      await program.methods
+        .queueTaskV0({
+          id: 4,
+          trigger: { now: {} },
+          transaction: { compiledV0: [transaction] },
+          crankReward: aboveMin,
+          freeTasks: 0,
+          description: "test",
+        })
+        .remainingAccounts(remainingAccounts)
+        .accounts({ payer: me, taskQueue, task })
+        .rpc();
+
+      const taskAcc = await program.account.taskV0.fetch(task);
+      expect(taskAcc.crankReward.toString()).to.eq(aboveMin.toString());
+    });
+
     it("does not let a task borrow the crank turner's signature", async () => {
       const crankTurner = Keypair.generate();
       const attacker = Keypair.generate();
@@ -701,6 +805,127 @@ describe("tuktuk", () => {
         },
         "confirmed"
       );
+    });
+
+    describe("returned task reward bounds", () => {
+      // Matches the min_crank_reward the surrounding beforeEach gives this queue.
+      const minCrankReward = new BN(10000);
+      let crankTurner: Keypair;
+
+      beforeEach(async () => {
+        crankTurner = Keypair.generate();
+        await sendInstructions(provider, [
+          SystemProgram.transfer({
+            fromPubkey: me,
+            toPubkey: taskQueue!,
+            lamports: 1000000000,
+          }),
+          SystemProgram.transfer({
+            fromPubkey: me,
+            toPubkey: crankTurner.publicKey,
+            lamports: 1000000000,
+          }),
+          SystemProgram.transfer({
+            fromPubkey: me,
+            toPubkey: queueAuthority!,
+            lamports: 1000000000,
+          }),
+        ]);
+      });
+
+      async function crank(task: PublicKey) {
+        const ixs = await runTask({
+          program,
+          task,
+          crankTurner: crankTurner.publicKey,
+        });
+        const tx = toVersionedTx(
+          await populateMissingDraftInfo(provider.connection, {
+            feePayer: crankTurner.publicKey,
+            instructions: ixs,
+          })
+        );
+        await tx.sign([crankTurner]);
+        await sendAndConfirmWithRetry(
+          provider.connection,
+          Buffer.from(tx.serialize()),
+          { skipPreflight: true, maxRetries: 0 },
+          "confirmed"
+        );
+      }
+
+      // A parent task returning one child with the given reward. `viaAccount` selects the
+      // return-account path rather than the return-data path; both create returned tasks.
+      async function scheduleReturning(
+        returnCrankReward: BN,
+        viaAccount: boolean
+      ) {
+        const parent = taskKey(taskQueue, 0)[0];
+        const args = {
+          taskId: 0,
+          freeTasks: 1,
+          returnCrankReward,
+          returnFreeTasks: 0,
+        };
+        const accounts = {
+          taskQueue,
+          task: parent,
+          taskQueueAuthority: taskQueueAuthorityKey(
+            taskQueue,
+            queueAuthority
+          )[0],
+        };
+        await (viaAccount
+          ? cpiProgram.methods.scheduleReturningViaAccount(args)
+          : cpiProgram.methods.scheduleReturning(args)
+        )
+          .accounts(accounts)
+          .rpc({ skipPreflight: true });
+        return { parent, child: taskKey(taskQueue, 1)[0] };
+      }
+
+      it("creates a returned task at exactly the queue minimum reward", async () => {
+        const { parent, child } = await scheduleReturning(
+          minCrankReward,
+          false
+        );
+
+        await crank(parent);
+
+        const childAcc = await program.account.taskV0.fetch(child);
+        expect(childAcc.crankReward.toString()).to.eq(
+          minCrankReward.toString()
+        );
+      });
+
+      it("rejects a returned task with a reward above the queue minimum", async () => {
+        const { parent, child } = await scheduleReturning(
+          minCrankReward.muln(2),
+          false
+        );
+
+        const before = await provider.connection.getBalance(taskQueue);
+        await crank(parent);
+        const after = await provider.connection.getBalance(taskQueue);
+
+        expect(await program.account.taskV0.fetchNullable(child)).to.be.null;
+        // Rent refunds go to the task's payer, so an untouched queue is exactly unchanged.
+        expect(after).to.eq(before);
+      });
+
+      it("rejects an above minimum returned task handed back in an account", async () => {
+        const { parent, child } = await scheduleReturning(
+          minCrankReward.muln(2),
+          true
+        );
+
+        const before = await provider.connection.getBalance(taskQueue);
+        await crank(parent);
+        const after = await provider.connection.getBalance(taskQueue);
+
+        expect(await program.account.taskV0.fetchNullable(child)).to.be.null;
+        expect(after).to.eq(before);
+      });
     });
   });
 });

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -892,7 +892,6 @@ describe("tuktuk", () => {
           taskId: 0,
           freeTasks: parentFreeTasks,
           returnCrankReward,
-          returnFreeTasks: 0,
         };
         const accounts = {
           taskQueue,

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -979,6 +979,47 @@ describe("tuktuk", () => {
           .null;
       });
 
+      it("fails the run when the free task account is not the id's PDA", async () => {
+        // The turner picks the free-task accounts as well as the ids. Pairing a valid unused id
+        // with a different (empty) task PDA must fail the run, not drop the child and pay out.
+        const { parent, child } = await scheduleReturning(minCrankReward, false);
+
+        const ixs = await runTask({
+          program,
+          task: parent,
+          crankTurner: crankTurner.publicKey,
+          nextAvailableTaskIds: [1],
+        });
+        // Swap the free-task account for a different, still-empty task PDA.
+        const ix = ixs[0];
+        ix.keys[ix.keys.length - 1].pubkey = taskKey(taskQueue, 99)[0];
+        const tx = toVersionedTx(
+          await populateMissingDraftInfo(provider.connection, {
+            feePayer: crankTurner.publicKey,
+            instructions: ixs,
+          }),
+        );
+        await tx.sign([crankTurner]);
+
+        let failed = false;
+        try {
+          await sendAndConfirmWithRetry(
+            provider.connection,
+            Buffer.from(tx.serialize()),
+            { skipPreflight: true, maxRetries: 0 },
+            "confirmed",
+          );
+        } catch (e) {
+          failed = true;
+        }
+        expect(failed).to.be.true;
+
+        // Reverted, so the parent is still queued for an honest turner.
+        expect(await program.account.taskV0.fetchNullable(child)).to.be.null;
+        expect(await program.account.taskV0.fetchNullable(parent)).to.not.be
+          .null;
+      });
+
       it("rejects an above minimum returned task handed back in an account", async () => {
         const { parent, child } = await scheduleReturning(
           minCrankReward.muln(2),

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -255,6 +255,31 @@ describe("tuktuk", () => {
       expect(code).to.eq("MismatchedFreeTaskCounts");
     });
 
+    it("rejects more accounts than the task's transaction and ids need", async () => {
+      const task = await queueTask(6, 0);
+
+      let code: string | undefined;
+      try {
+        // Surplus accounts are forwarded to every inner CPI, so the count is exact in both
+        // directions rather than a lower bound.
+        await program.methods
+          .runTaskV0({ freeTaskIds: [] })
+          .accounts({ task, crankTurner: me })
+          .remainingAccounts([
+            ...taskAccounts(),
+            {
+              pubkey: taskKey(taskQueue, 200)[0],
+              isWritable: true,
+              isSigner: false,
+            },
+          ])
+          .rpc();
+      } catch (e: any) {
+        code = e?.error?.errorCode?.code ?? JSON.stringify(e);
+      }
+      expect(code).to.eq("MismatchedFreeTaskCounts");
+    });
+
     it("allows a payer funded task above the queue minimum reward", async () => {
       const task = taskKey(taskQueue, 4)[0];
       const aboveMin = crankReward.muln(2);
@@ -860,11 +885,12 @@ describe("tuktuk", () => {
       async function scheduleReturning(
         returnCrankReward: BN,
         viaAccount: boolean,
+        parentFreeTasks = 1,
       ) {
         const parent = taskKey(taskQueue, 0)[0];
         const args = {
           taskId: 0,
-          freeTasks: 1,
+          freeTasks: parentFreeTasks,
           returnCrankReward,
           returnFreeTasks: 0,
         };
@@ -913,6 +939,36 @@ describe("tuktuk", () => {
         expect(await program.account.taskV0.fetchNullable(child)).to.be.null;
         // Rent refunds go to the task's payer, so an untouched queue is exactly unchanged.
         expect(after).to.eq(before);
+      });
+
+      it("creates a returned task handed back in an account at the queue minimum", async () => {
+        const { parent, child } = await scheduleReturning(minCrankReward, true);
+
+        await crank(parent);
+
+        // The return-account path is a separate call site of create_new_task, so pin that it
+        // still creates. Without this, the rejection test below is equally satisfied by that
+        // path doing nothing at all.
+        const childAcc = await program.account.taskV0.fetch(child);
+        expect(childAcc.crankReward.toString()).to.eq(
+          minCrankReward.toString(),
+        );
+      });
+
+      it("drops a returned task the parent had no free task id for", async () => {
+        // The parent declares no free tasks but its program still returns one, so no id is
+        // left to give it. create_new_task errors, and the return-data handler swallows that:
+        // the child is not created and the run still succeeds.
+        const { parent, child } = await scheduleReturning(
+          minCrankReward,
+          false,
+          0,
+        );
+
+        await crank(parent);
+
+        expect(await program.account.taskV0.fetchNullable(child)).to.be.null;
+        expect(await program.account.taskV0.fetchNullable(parent)).to.be.null;
       });
 
       it("rejects an above minimum returned task handed back in an account", async () => {

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -955,20 +955,29 @@ describe("tuktuk", () => {
         );
       });
 
-      it("drops a returned task the parent had no free task id for", async () => {
-        // The parent declares no free tasks but its program still returns one, so no id is
-        // left to give it. create_new_task errors, and the return-data handler swallows that:
-        // the child is not created and the run still succeeds.
+      it("fails the run when a returned task has no free task id left", async () => {
+        // The parent declares no free tasks but its program still returns one, so no id is left
+        // to give it. The turner picks how many ids to supply, so this must fail the run rather
+        // than drop the child: otherwise a turner could truncate a task's children — including
+        // a recurring task's own reschedule — and still be paid.
         const { parent, child } = await scheduleReturning(
           minCrankReward,
           false,
           0,
         );
 
-        await crank(parent);
+        let failed = false;
+        try {
+          await crank(parent);
+        } catch (e) {
+          failed = true;
+        }
+        expect(failed).to.be.true;
 
+        // The run reverted, so the parent is still queued for an honest turner to run.
         expect(await program.account.taskV0.fetchNullable(child)).to.be.null;
-        expect(await program.account.taskV0.fetchNullable(parent)).to.be.null;
+        expect(await program.account.taskV0.fetchNullable(parent)).to.not.be
+          .null;
       });
 
       it("rejects an above minimum returned task handed back in an account", async () => {

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -67,9 +67,8 @@ describe("tuktuk", () => {
         .rpc();
     }
 
-    const tuktukConfigAcc = await program.account.tuktukConfigV0.fetch(
-      tuktukConfig
-    );
+    const tuktukConfigAcc =
+      await program.account.tuktukConfigV0.fetch(tuktukConfig);
     expect(tuktukConfigAcc.authority.toBase58()).to.eq(me.toBase58());
   });
 
@@ -143,7 +142,7 @@ describe("tuktuk", () => {
       bumpBuffer.writeUint8(bump);
       ({ transaction, remainingAccounts } = await compileTransaction(
         instructions,
-        [[Buffer.from("test"), bumpBuffer]]
+        [[Buffer.from("test"), bumpBuffer]],
       ));
     });
     it("allows creating tasks", async () => {
@@ -298,7 +297,7 @@ describe("tuktuk", () => {
               lamports: stolen,
             }),
           ],
-          []
+          [],
         );
 
       const task = taskKey(taskQueue, 1)[0];
@@ -316,7 +315,7 @@ describe("tuktuk", () => {
         .rpc();
 
       const balanceBefore = await provider.connection.getBalance(
-        crankTurner.publicKey
+        crankTurner.publicKey,
       );
 
       const ixs = await runTask({
@@ -328,7 +327,7 @@ describe("tuktuk", () => {
         await populateMissingDraftInfo(provider.connection, {
           feePayer: crankTurner.publicKey,
           instructions: ixs,
-        })
+        }),
       );
       await tx.sign([crankTurner]);
 
@@ -338,7 +337,7 @@ describe("tuktuk", () => {
           provider.connection,
           Buffer.from(tx.serialize()),
           { skipPreflight: true, maxRetries: 0 },
-          "confirmed"
+          "confirmed",
         );
       } catch (e) {
         failed = true;
@@ -346,7 +345,7 @@ describe("tuktuk", () => {
       expect(failed).to.be.true;
 
       const balanceAfter = await provider.connection.getBalance(
-        crankTurner.publicKey
+        crankTurner.publicKey,
       );
       expect(balanceBefore - balanceAfter).to.be.lessThan(stolen);
       expect(await provider.connection.getBalance(attacker.publicKey)).to.eq(0);
@@ -369,9 +368,8 @@ describe("tuktuk", () => {
           taskQueueNameMapping: taskQueueNameMappingKey(tuktukConfig, name)[0],
         })
         .rpc({ skipPreflight: true });
-      const taskQueueAcc = await program.account.taskQueueV0.fetchNullable(
-        taskQueue
-      );
+      const taskQueueAcc =
+        await program.account.taskQueueV0.fetchNullable(taskQueue);
       expect(taskQueueAcc).to.be.null;
     });
 
@@ -430,13 +428,13 @@ describe("tuktuk", () => {
             });
             const serialized = await RemoteTaskTransactionV0.serialize(
               program.coder.accounts,
-              remoteTx
+              remoteTx,
             );
             return {
               remoteTaskTransaction: serialized,
               remainingAccounts: remainingAccounts,
               signature: Buffer.from(
-                sign.detached(Uint8Array.from(serialized), signer.secretKey)
+                sign.detached(Uint8Array.from(serialized), signer.secretKey),
               ),
             };
           },
@@ -445,7 +443,7 @@ describe("tuktuk", () => {
           await populateMissingDraftInfo(provider.connection, {
             feePayer: crankTurner.publicKey,
             instructions: ixs,
-          })
+          }),
         );
         await tx.sign([crankTurner]);
         await sendAndConfirmWithRetry(
@@ -455,7 +453,7 @@ describe("tuktuk", () => {
             skipPreflight: true,
             maxRetries: 0,
           },
-          "confirmed"
+          "confirmed",
         );
       });
     });
@@ -498,7 +496,7 @@ describe("tuktuk", () => {
         ]);
 
         const crankTurnerBalanceBefore = await provider.connection.getBalance(
-          crankTurner.publicKey
+          crankTurner.publicKey,
         );
 
         const ixs = await runTask({
@@ -510,7 +508,7 @@ describe("tuktuk", () => {
           await populateMissingDraftInfo(provider.connection, {
             feePayer: crankTurner.publicKey,
             instructions: ixs,
-          })
+          }),
         );
         await tx.sign([crankTurner]);
         const taskAcc = await program.account.taskV0.fetch(task);
@@ -521,11 +519,11 @@ describe("tuktuk", () => {
             skipPreflight: true,
             maxRetries: 0,
           },
-          "confirmed"
+          "confirmed",
         );
 
         const crankTurnerBalanceAfter = await provider.connection.getBalance(
-          crankTurner.publicKey
+          crankTurner.publicKey,
         );
 
         // Get the transaction fee
@@ -549,7 +547,7 @@ describe("tuktuk", () => {
           `Crank turner balance change incorrect. Expected change: ${expectedBalanceChange}, ` +
             `Actual change: ${actualBalanceChange}, ` +
             `Reward: ${expectedReward}, ` +
-            `TX fee: ${txFee}`
+            `TX fee: ${txFee}`,
         );
       });
 
@@ -571,18 +569,18 @@ describe("tuktuk", () => {
     let taskQueue: PublicKey;
     const queueAuthority = PublicKey.findProgramAddressSync(
       [Buffer.from("queue_authority")],
-      new PublicKey("cpic9j9sjqvhn2ZX3mqcCgzHKCwiiBTyEszyCwN7MBC")
+      new PublicKey("cpic9j9sjqvhn2ZX3mqcCgzHKCwiiBTyEszyCwN7MBC"),
     )[0];
 
     beforeEach(async () => {
       const idl = await Program.fetchIdl(
         new PublicKey("cpic9j9sjqvhn2ZX3mqcCgzHKCwiiBTyEszyCwN7MBC"),
-        provider
+        provider,
       );
 
       cpiProgram = new Program<CpiExample>(
         idl as CpiExample,
-        provider
+        provider,
       ) as Program<CpiExample>;
       if (!(await program.account.tuktukConfigV0.fetchNullable(tuktukConfig))) {
         await program.methods
@@ -660,7 +658,7 @@ describe("tuktuk", () => {
         await populateMissingDraftInfo(provider.connection, {
           feePayer: crankTurner.publicKey,
           instructions: ixs,
-        })
+        }),
       );
       await tx.sign([crankTurner]);
       await sendAndConfirmWithRetry(
@@ -670,7 +668,7 @@ describe("tuktuk", () => {
           skipPreflight: true,
           maxRetries: 0,
         },
-        "confirmed"
+        "confirmed",
       );
       await sleep(1000);
       const ixs2 = await runTask({
@@ -682,7 +680,7 @@ describe("tuktuk", () => {
         await populateMissingDraftInfo(provider.connection, {
           feePayer: crankTurner.publicKey,
           instructions: ixs2,
-        })
+        }),
       );
       await tx2.sign([crankTurner]);
       await sendAndConfirmWithRetry(
@@ -692,7 +690,7 @@ describe("tuktuk", () => {
           skipPreflight: true,
           maxRetries: 0,
         },
-        "confirmed"
+        "confirmed",
       );
     });
 
@@ -709,7 +707,7 @@ describe("tuktuk", () => {
           task: freeTasks[0],
           taskQueueAuthority: taskQueueAuthorityKey(
             taskQueue,
-            queueAuthority
+            queueAuthority,
           )[0],
         });
       await sendInstructions(provider, [
@@ -745,7 +743,7 @@ describe("tuktuk", () => {
             feePayer: crankTurner.publicKey,
             computeUnits: 1000000000,
           }),
-        })
+        }),
       );
       await tx.sign([crankTurner]);
       await sendAndConfirmWithRetry(
@@ -755,7 +753,7 @@ describe("tuktuk", () => {
           skipPreflight: true,
           maxRetries: 0,
         },
-        "confirmed"
+        "confirmed",
       );
       await sleep(1000);
       const ixs2 = await runTask({
@@ -772,7 +770,7 @@ describe("tuktuk", () => {
             feePayer: crankTurner.publicKey,
             computeUnits: 1000000000,
           }),
-        })
+        }),
       );
       await tx2.sign([crankTurner]);
       await sendAndConfirmWithRetry(
@@ -782,7 +780,7 @@ describe("tuktuk", () => {
           skipPreflight: true,
           maxRetries: 0,
         },
-        "confirmed"
+        "confirmed",
       );
       const ixs3 = await runTask({
         program,
@@ -793,7 +791,7 @@ describe("tuktuk", () => {
         await populateMissingDraftInfo(provider.connection, {
           feePayer: crankTurner.publicKey,
           instructions: ixs3,
-        })
+        }),
       );
       await tx3.sign([crankTurner]);
       await sendAndConfirmWithRetry(
@@ -803,7 +801,7 @@ describe("tuktuk", () => {
           skipPreflight: true,
           maxRetries: 0,
         },
-        "confirmed"
+        "confirmed",
       );
     });
 
@@ -838,19 +836,22 @@ describe("tuktuk", () => {
           program,
           task,
           crankTurner: crankTurner.publicKey,
+          // Pin the child's task id so the tests below can assert on taskKey(taskQueue, 1);
+          // by default runTask picks a random free id from the bitmap.
+          nextAvailableTaskIds: [1],
         });
         const tx = toVersionedTx(
           await populateMissingDraftInfo(provider.connection, {
             feePayer: crankTurner.publicKey,
             instructions: ixs,
-          })
+          }),
         );
         await tx.sign([crankTurner]);
         await sendAndConfirmWithRetry(
           provider.connection,
           Buffer.from(tx.serialize()),
           { skipPreflight: true, maxRetries: 0 },
-          "confirmed"
+          "confirmed",
         );
       }
 
@@ -858,7 +859,7 @@ describe("tuktuk", () => {
       // return-account path rather than the return-data path; both create returned tasks.
       async function scheduleReturning(
         returnCrankReward: BN,
-        viaAccount: boolean
+        viaAccount: boolean,
       ) {
         const parent = taskKey(taskQueue, 0)[0];
         const args = {
@@ -872,12 +873,13 @@ describe("tuktuk", () => {
           task: parent,
           taskQueueAuthority: taskQueueAuthorityKey(
             taskQueue,
-            queueAuthority
+            queueAuthority,
           )[0],
         };
-        await (viaAccount
-          ? cpiProgram.methods.scheduleReturningViaAccount(args)
-          : cpiProgram.methods.scheduleReturning(args)
+        await (
+          viaAccount
+            ? cpiProgram.methods.scheduleReturningViaAccount(args)
+            : cpiProgram.methods.scheduleReturning(args)
         )
           .accounts(accounts)
           .rpc({ skipPreflight: true });
@@ -887,21 +889,21 @@ describe("tuktuk", () => {
       it("creates a returned task at exactly the queue minimum reward", async () => {
         const { parent, child } = await scheduleReturning(
           minCrankReward,
-          false
+          false,
         );
 
         await crank(parent);
 
         const childAcc = await program.account.taskV0.fetch(child);
         expect(childAcc.crankReward.toString()).to.eq(
-          minCrankReward.toString()
+          minCrankReward.toString(),
         );
       });
 
       it("rejects a returned task with a reward above the queue minimum", async () => {
         const { parent, child } = await scheduleReturning(
           minCrankReward.muln(2),
-          false
+          false,
         );
 
         const before = await provider.connection.getBalance(taskQueue);
@@ -916,7 +918,7 @@ describe("tuktuk", () => {
       it("rejects an above minimum returned task handed back in an account", async () => {
         const { parent, child } = await scheduleReturning(
           minCrankReward.muln(2),
-          true
+          true,
         );
 
         const before = await provider.connection.getBalance(taskQueue);


### PR DESCRIPTION
Tightens three bounds in `run_task_v0` so the values a crank turner supplies
are checked against what the task and the queue already declare.

## Invariants

**A task may spawn no more children than it declared.** `free_task_ids` comes
from the crank turner, so `task.free_tasks` — fixed when the task was queued —
is the authoritative bound. The check sits in `handler` rather than
`create_new_task`: `process_instruction` swallows every error out of
`process_return_data`, so a check on that path would drop tasks silently
instead of failing the instruction.

**A returned task is funded by the queue, so `min_crank_reward` is its ceiling
as well as its floor.** `queue_task_v0` stays uncapped, because there the payer
funds the reward from their own account. The cap sits at the existing floor
check, ahead of `free_task_index += 1` and `tasks_to_set.push`, so a rejected
task consumes no free-task slot and sets no bitmap bit.

**The free-task account count is checked as a sum, not a difference.** The
turner chooses how many accounts to pass; too few underflowed
`remaining_accounts.len() - free_tasks_start_index` and panicked instead of
returning `MismatchedFreeTaskCounts`.

## Compatibility

- Both the Rust crank turner and the TypeScript SDK derive `free_task_ids` from
  `task.free_tasks` via `next_available_task_ids_excluding_in_progress`, which
  returns at most `n = task.free_tasks` ids and an empty vec when that is 0.
  Neither can exceed the new bound.
- Every task currently queued on the main queue (4,681 of them) carries a
  `crank_reward` equal to that queue's `min_crank_reward`, so the ceiling
  matches what is already in flight.
- Each queued task's declared budget matches its flow's real fan-out, and the
  check is `declared >= actual`, so under-returning stays fine.

## Tests

Added to `tests/tuktuk.ts`, with parameterised `cpi-example` instructions so a
test can drive a returned task's reward and spawn budget:

- rejects more free task ids than the task declared
- accepts exactly as many free task ids as the task declared
- rejects fewer accounts than the task's transaction needs
- allows a payer funded task above the queue minimum reward (the uncapped
  `queue_task_v0` path must not regress)
- creates a returned task at exactly the queue minimum reward
- rejects a returned task with a reward above the queue minimum
- rejects an above minimum returned task handed back in an account (the
  return-account path is a separate call site of `create_new_task`)

Each new guard was checked by reverting it one at a time and confirming the
matching test fails and the rest of the suite still passes.
