### PR TITLE
Bound task-supplied account indices and task id selection

### DIFF
--- a/solana-programs/Cargo.lock
+++ b/solana-programs/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana-programs/packages/cron-sdk/src/index.ts
+++ b/solana-programs/packages/cron-sdk/src/index.ts
@@ -34,7 +34,12 @@ export async function createCronJob(program: Program<Cron>, {
   const userCronJobs = await program.account.userCronJobsV0.fetchNullable(userCronJobsK);
   const nextCronJobId = userCronJobs?.nextCronJobId ?? 0;
   const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(taskQueue);
-  const nextTaskId = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 1, false)[0];
+  const nextTaskId = nextAvailableTaskIds(
+    taskQueueAcc.taskBitmap,
+    1,
+    false,
+    taskQueueAcc.capacity
+  )[0];
   return program.methods
     .initializeCronJobV0(args)
     .preInstructions([

--- a/solana-programs/packages/tuktuk-sdk/src/index.ts
+++ b/solana-programs/packages/tuktuk-sdk/src/index.ts
@@ -3,37 +3,12 @@ import { customSignerKey, taskKey, taskQueueKey, taskQueueNameMappingKey, tuktuk
 import { Tuktuk } from "@helium/tuktuk-idls/lib/types/tuktuk";
 import { MethodsBuilder } from "@coral-xyz/anchor/dist/cjs/program/namespace/methods";
 import { PublicKey, TransactionInstruction } from "@solana/web3.js";
-import { compileTransaction } from "./transaction";
+import { compileTransaction, nextAvailableTaskIds } from "./transaction";
 
 export { init } from "./init"
 export * from "./constants"
 export * from "./pdas"
 export * from "./transaction"
-
-export function nextAvailableTaskIds(taskBitmap: Buffer, n: number, random: boolean = true): number[] {
-  if (n === 0) {
-    return [];
-  }
-
-  const availableTaskIds: number[] = [];
-  const randStart = random ? Math.floor(Math.random() * taskBitmap.length) : 0;
-  for (let byteOffset = 0; byteOffset < taskBitmap.length; byteOffset++) {
-    const byteIdx = (byteOffset + randStart) % taskBitmap.length;
-    const byte = taskBitmap[byteIdx];
-    if (byte !== 0xff) {
-      // If byte is not all 1s
-      for (let bitIdx = 0; bitIdx < 8; bitIdx++) {
-        if ((byte & (1 << bitIdx)) === 0) {
-          availableTaskIds.push(byteIdx * 8 + bitIdx);
-          if (availableTaskIds.length === n) {
-            return availableTaskIds;
-          }
-        }
-      }
-    }
-  }
-  return availableTaskIds;
-}
 
 export const TUKTUK_CONFIG = tuktukConfigKey()[0];
 
@@ -78,7 +53,12 @@ export async function queueTask(program: Program<Tuktuk>, {
   args: Omit<QueueTaskArgsV0, "id">,
 }): Promise<MethodsBuilder<Tuktuk, Tuktuk["instructions"][6]>> {
   const taskQueueAcc = await program.account.taskQueueV0.fetch(taskQueue);
-  const taskId = nextAvailableTaskIds(taskQueueAcc.taskBitmap, 1)[0];
+  const taskId = nextAvailableTaskIds(
+    taskQueueAcc.taskBitmap,
+    1,
+    true,
+    taskQueueAcc.capacity
+  )[0];
   const task = taskKey(taskQueue, taskId)[0];
 
   // Queue the task

--- a/solana-programs/packages/tuktuk-sdk/src/transaction.ts
+++ b/solana-programs/packages/tuktuk-sdk/src/transaction.ts
@@ -193,19 +193,39 @@ export function compileTransaction(
   };
 }
 
-function nextAvailableTaskIds(taskBitmap: Buffer, n: number): number[] {
+/**
+ * Pick up to `n` unused task ids from a task queue's bitmap.
+ *
+ * The bitmap is a whole number of bytes, so its final byte carries up to seven bits past
+ * `capacity`. Those bits read as unused while the program rejects any id at or beyond
+ * capacity, so the bound has to be applied here — it cannot be inferred from the buffer.
+ *
+ * `random` starts the scan at an arbitrary byte, which keeps concurrent crank turners from
+ * converging on the same ids. Both trailing arguments are required: a caller that omits
+ * `capacity` would otherwise compare every id against `undefined` and silently get nothing
+ * back, and callers written against the older two-and-a-flag signature should fail loudly.
+ */
+export function nextAvailableTaskIds(
+  taskBitmap: Buffer,
+  n: number,
+  random: boolean,
+  capacity: number
+): number[] {
   if (n === 0) {
     return [];
   }
 
   const availableTaskIds: number[] = [];
-  for (let byteIdx = 0; byteIdx < taskBitmap.length; byteIdx++) {
+  const randStart = random ? Math.floor(Math.random() * taskBitmap.length) : 0;
+  for (let byteOffset = 0; byteOffset < taskBitmap.length; byteOffset++) {
+    const byteIdx = (byteOffset + randStart) % taskBitmap.length;
     const byte = taskBitmap[byteIdx];
     if (byte !== 0xff) {
       // If byte is not all 1s
       for (let bitIdx = 0; bitIdx < 8; bitIdx++) {
-        if ((byte & (1 << bitIdx)) === 0) {
-          availableTaskIds.push(byteIdx * 8 + bitIdx);
+        const id = byteIdx * 8 + bitIdx;
+        if (id < capacity && (byte & (1 << bitIdx)) === 0) {
+          availableTaskIds.push(id);
           if (availableTaskIds.length === n) {
             return availableTaskIds;
           }
@@ -296,7 +316,12 @@ export async function runTask({
 
     const nextAvailable =
       argsNextAvailableTaskIds?.slice(0, freeTasks) ||
-      nextAvailableTaskIds(taskQueueAcc.taskBitmap, freeTasks);
+      nextAvailableTaskIds(
+        taskQueueAcc.taskBitmap,
+        freeTasks,
+        true,
+        taskQueueAcc.capacity
+      );
     const freeTasksAccounts = nextAvailable.map((id) => ({
       pubkey: taskKey(taskQueue, id)[0],
       isWritable: true,
@@ -318,7 +343,12 @@ export async function runTask({
   } else {
     const nextAvailable =
       argsNextAvailableTaskIds?.slice(0, freeTasks) ||
-      nextAvailableTaskIds(taskQueueAcc.taskBitmap, freeTasks);
+      nextAvailableTaskIds(
+        taskQueueAcc.taskBitmap,
+        freeTasks,
+        true,
+        taskQueueAcc.capacity
+      );
     const freeTasksAccounts = nextAvailable.map((id) => ({
       pubkey: taskKey(taskQueue, id)[0],
       isWritable: true,

--- a/solana-programs/programs/tuktuk/Cargo.toml
+++ b/solana-programs/programs/tuktuk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk"
-version = "0.2.7"
+version = "0.2.8"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -178,13 +178,16 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             })
             .collect();
 
+        // Seeds past the prefix come from the task's transaction, so they are not guaranteed to
+        // resolve to a valid off-curve address.
         let signer_addresses = signers_inner_u8
             .iter()
             .map(|s| {
                 let seeds: Vec<&[u8]> = s.iter().map(|v| v.as_slice()).collect();
-                Pubkey::create_program_address(&seeds, ctx.program_id).unwrap()
+                Pubkey::create_program_address(&seeds, ctx.program_id)
+                    .map_err(|_| error!(ErrorCode::InvalidSignerSeeds))
             })
-            .collect();
+            .collect::<Result<_>>()?;
 
         Ok(Self {
             ctx,
@@ -205,14 +208,24 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         ix: &CompiledInstructionV0,
         remaining_accounts: &[AccountInfo<'info>],
     ) -> Result<()> {
-        let mut accounts = Vec::new();
-        let mut account_infos = Vec::new();
+        // The allocator never frees, so a Vec that grows leaks every intermediate buffer. These
+        // hold the instruction's accounts and, for everything but memo, the free tasks too.
+        // Reserve against what can actually be pushed: every index kept below resolves within
+        // `remaining_accounts`, so that is the ceiling however many `ix.accounts` names.
+        let free_tasks = &self.ctx.remaining_accounts[self.free_task_index..];
+        let capacity = ix.accounts.len().min(remaining_accounts.len()) + free_tasks.len();
+        let mut accounts = Vec::with_capacity(capacity);
+        let mut account_infos = Vec::with_capacity(capacity);
 
         msg!("Signer addresses: {:?}", self.signer_addresses);
 
         for i in &ix.accounts {
-            let acct = remaining_accounts[*i as usize].clone();
-            let mut acct = acct.clone();
+            // Indices come from the task's transaction and address a slice whose length the crank
+            // turner chooses, so neither side of this bound is fixed by the program.
+            let mut acct = remaining_accounts
+                .get(*i as usize)
+                .ok_or(error!(ErrorCode::InvalidAccountIndex))?
+                .clone();
             // A task may only sign for this queue's own `b"custom"` PDAs. Signer privilege is
             // never inherited from the outer transaction: the crank turner is an arbitrary,
             // untrusted account, and forwarding its signature would let any task drain it.
@@ -228,10 +241,12 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         }
 
         // Pass free tasks as remaining accounts so the task can know which IDs will be used
-        let program_id = remaining_accounts[ix.program_id_index as usize].key;
+        let program_id = remaining_accounts
+            .get(ix.program_id_index as usize)
+            .ok_or(error!(ErrorCode::InvalidAccountIndex))?
+            .key;
         // Ignore memo program because it expects every account passed to be a signer.
         if *program_id != MEMO_PROGRAM_ID {
-            let free_tasks = &self.ctx.remaining_accounts[self.free_task_index..];
             accounts.extend(free_tasks.iter().cloned());
             account_infos.extend(free_tasks.iter().map(|acct| AccountMeta {
                 pubkey: acct.key(),
@@ -501,8 +516,14 @@ pub fn handler<'info>(
         TransactionSourceV0::RemoteV0 { signer, .. } => {
             let ix_index =
                 load_current_index_checked(&ctx.accounts.sysvar_instructions.to_account_info())?;
+            // The signature this task is verified against lives in the instruction immediately
+            // before this one, so there has to be one. The crank turner composes the transaction
+            // and can place this instruction first.
+            let verify_ix_index = ix_index
+                .checked_sub(1)
+                .ok_or(error!(ErrorCode::MalformedRemoteTransaction))?;
             let ix: Instruction = load_instruction_at_checked(
-                ix_index.checked_sub(1).unwrap() as usize,
+                verify_ix_index as usize,
                 &ctx.accounts.sysvar_instructions,
             )?;
             let data = utils::ed25519::verify_ed25519_ix(&ix, signer.to_bytes().as_slice())?;

--- a/solana-programs/tests/cron.ts
+++ b/solana-programs/tests/cron.ts
@@ -38,7 +38,7 @@ import {
 import chai from "chai";
 import { Cron } from "../target/types/cron";
 import { Tuktuk } from "../target/types/tuktuk";
-import { ensureIdls, makeid } from "./utils";
+import { ensureIdls, makeid, readyTasks } from "./utils";
 const { expect } = chai;
 
 describe("cron", () => {
@@ -236,13 +236,21 @@ describe("cron", () => {
       // Wait for next scheduled execution
       await sleep(2000);
 
-      // Run the scheduled task
-      const task2 = taskKey(taskQueue, 1)[0];
-      const task3 = taskKey(taskQueue, 2)[0];
+      // Run the scheduled tasks. A turner takes its free task ids from a randomized start so
+      // concurrent turners do not collide, so read back which tasks are due rather than
+      // assuming where they landed.
       const taskQueueAcc = await tuktukProgram.account.taskQueueV0.fetch(taskQueue);
+      const due = await readyTasks(tuktukProgram, taskQueue, 2);
+      expect(due).to.have.length(2);
+      const [task2, task3] = due;
       const task2Acc = await tuktukProgram.account.taskV0.fetch(task2);
       const task3Acc = await tuktukProgram.account.taskV0.fetch(task3);
-      const nextAvailable = nextAvailableTaskIds(taskQueueAcc.taskBitmap, task2Acc.freeTasks + task3Acc.freeTasks);
+      const nextAvailable = nextAvailableTaskIds(
+        taskQueueAcc.taskBitmap,
+        task2Acc.freeTasks + task3Acc.freeTasks,
+        true,
+        taskQueueAcc.capacity
+      );
       const ixs2 = await runTask({
         program: tuktukProgram,
         task: task2,

--- a/solana-programs/tests/tuktuk.ts
+++ b/solana-programs/tests/tuktuk.ts
@@ -14,6 +14,7 @@ import {
   customSignerKey,
   RemoteTaskTransactionV0,
   taskQueueAuthorityKey,
+  nextAvailableTaskIds,
 } from "@helium/tuktuk-sdk";
 import {
   AccountMeta,
@@ -32,7 +33,7 @@ import {
   toVersionedTx,
   withPriorityFees,
 } from "@helium/spl-utils";
-import { ensureIdls, makeid } from "./utils";
+import { ensureIdls, makeid, readyTasks } from "./utils";
 import {
   createAssociatedTokenAccountInstruction,
   createTransferInstruction,
@@ -40,6 +41,32 @@ import {
 } from "@solana/spl-token";
 import { sign } from "tweetnacl";
 const { expect } = chai;
+
+describe("nextAvailableTaskIds", () => {
+  // 100 ids need 13 bytes, so the final byte carries bits 100..103. They are zero and so read
+  // as unused, while the program refuses any id at or past capacity.
+  const capacity = 100;
+  const bitmap = Buffer.alloc(Math.ceil(capacity / 8));
+
+  it("never returns an id at or past capacity", () => {
+    // Fill every byte but the last, leaving only the trailing partial byte to pick from.
+    bitmap.fill(0xff, 0, bitmap.length - 1);
+    bitmap[bitmap.length - 1] = 0;
+
+    expect(nextAvailableTaskIds(bitmap, 8, false, capacity)).to.deep.eq([
+      96, 97, 98, 99,
+    ]);
+  });
+
+  it("offers exactly capacity ids when the whole queue is free", () => {
+    // Asking for more than exist forces the full scan, so the count is the bound itself
+    // rather than a sample that happens to avoid the tail.
+    bitmap.fill(0);
+    const ids = nextAvailableTaskIds(bitmap, capacity * 2, false, capacity);
+    expect(ids).to.have.length(capacity);
+    expect(Math.max(...ids)).to.eq(capacity - 1);
+  });
+});
 
 describe("tuktuk", () => {
   // Configure the client to use the local cluster.
@@ -648,7 +675,6 @@ describe("tuktuk", () => {
     });
     it("allows scheduling a task", async () => {
       const freeTask1 = taskKey(taskQueue, 0)[0];
-      const freeTask2 = taskKey(taskQueue, 1)[0];
       const crankTurner = Keypair.generate();
       const method = await cpiProgram.methods.schedule(0).accounts({
         taskQueue,
@@ -696,6 +722,8 @@ describe("tuktuk", () => {
         "confirmed",
       );
       await sleep(1000);
+      // The run above chose the child's id, so look it up instead of assuming it.
+      const freeTask2 = (await readyTasks(program, taskQueue))[0];
       const ixs2 = await runTask({
         program,
         task: freeTask2,
@@ -781,9 +809,11 @@ describe("tuktuk", () => {
         "confirmed",
       );
       await sleep(1000);
+      // Same here: the returned tasks landed on ids the run picked.
+      const nextTask = (await readyTasks(program, taskQueue))[0];
       const ixs2 = await runTask({
         program,
-        task: freeTasks[1],
+        task: nextTask,
         crankTurner: crankTurner.publicKey,
       });
       const tx2 = toVersionedTx(
@@ -807,9 +837,11 @@ describe("tuktuk", () => {
         },
         "confirmed",
       );
+      // Running the previous task queued one a second out, so take a task that is due now.
+      const thirdTask = (await readyTasks(program, taskQueue))[0];
       const ixs3 = await runTask({
         program,
-        task: freeTasks[2],
+        task: thirdTask,
         crankTurner: crankTurner.publicKey,
       });
       const tx3 = toVersionedTx(

--- a/solana-programs/tests/utils.ts
+++ b/solana-programs/tests/utils.ts
@@ -1,4 +1,8 @@
+import { Program } from "@coral-xyz/anchor";
+import { taskKey } from "@helium/tuktuk-sdk";
+import { PublicKey } from "@solana/web3.js";
 import { execSync } from "child_process";
+import { Tuktuk } from "../target/types/tuktuk";
 
 export const ANCHOR_PATH = "anchor";
 
@@ -49,4 +53,65 @@ export function makeid(length: number) {
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Ids the queue's bitmap marks as holding a task, ascending. */
+function usedTaskIds(taskBitmap: Buffer, capacity: number): number[] {
+  const ids: number[] = [];
+  for (let byteIdx = 0; byteIdx < taskBitmap.length; byteIdx++) {
+    for (let bitIdx = 0; bitIdx < 8; bitIdx++) {
+      const id = byteIdx * 8 + bitIdx;
+      if (id < capacity && (taskBitmap[byteIdx] & (1 << bitIdx)) !== 0) {
+        ids.push(id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Tasks on the queue a crank turner could run, waiting for at least `minimum` of them.
+ *
+ * Two reasons a test cannot just name the id it expects. Turners take their free task ids from
+ * a randomized start so concurrent turners do not collide, so which id a task landed on is not
+ * predictable. And a queue holds tasks that are not yet due — running one fails with
+ * TaskNotReady — so the trigger has to be checked.
+ *
+ * Readiness is judged against the cluster's clock, which is the one the program compares
+ * against; this machine's can sit either side of it. A task queued a moment ahead becomes due
+ * shortly, so this waits rather than reporting a queue that is merely early as empty.
+ */
+export async function readyTasks(
+  program: Program<Tuktuk>,
+  taskQueue: PublicKey,
+  minimum: number = 1,
+  timeoutMs: number = 20000,
+): Promise<PublicKey[]> {
+  const { connection } = program.provider;
+  const deadline = Date.now() + timeoutMs;
+  let ready: PublicKey[] = [];
+
+  do {
+    const now =
+      (await connection.getBlockTime(await connection.getSlot())) ??
+      Math.floor(Date.now() / 1000);
+    const queue = await program.account.taskQueueV0.fetch(taskQueue);
+    ready = [];
+    for (const id of usedTaskIds(queue.taskBitmap, queue.capacity)) {
+      const key = taskKey(taskQueue, id)[0];
+      const task = await program.account.taskV0.fetchNullable(key);
+      // A set bit does not guarantee a task: the id is marked before creation finishes.
+      if (!task) continue;
+      const triggerTs = task.trigger.timestamp?.[0];
+      if (!triggerTs || triggerTs.toNumber() <= now) {
+        ready.push(key);
+      }
+    }
+    if (ready.length >= minimum) return ready;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  } while (Date.now() < deadline);
+
+  throw new Error(
+    `only ${ready.length} of ${minimum} tasks on ${taskQueue.toBase58()} came due within ${timeoutMs}ms`,
+  );
 }


### PR DESCRIPTION
Two pieces of tightening in `tuktuk` and the TypeScript SDK.

### `run_task_v0`: account indices and signer seeds

A task's compiled transaction supplies the account indices and signer seeds its instructions
use, and they address a slice whose length the crank turner chooses, so neither side of the
bound is fixed by the program. An index past the end, seeds that do not resolve to an address,
and a `RemoteV0` task whose verifying instruction has nowhere to sit now return errors instead
of panicking. `InvalidSignerSeeds` and `InvalidAccountIndex` were declared for this and had no
call sites until now.

All three sit on the path that propagates out of the instruction loop rather than the branch
where return-data errors are logged and carried on from, so a panic becomes a failed
transaction exactly as before rather than an instruction that quietly does not run.

The two per-instruction account vectors also take their capacity up front. The allocator does
not free, so a vector that grows leaves every earlier buffer behind; the reservation is bounded
by the accounts that can actually be pushed.

### Task id selection

A task bitmap is a whole number of bytes, so its final byte carries up to seven bits past the
queue's capacity. Those read as unused while the program will not accept an id at or beyond
capacity, and capacity cannot be recovered from the buffer — so `nextAvailableTaskIds` takes
it, as the Rust implementation always has.

The scan existed twice in TypeScript, and only the exported copy had the randomized start that
keeps concurrent crank turners off each other's ids; the copy `runTask` used still scanned from
the beginning. They are one function now, re-exported through the existing `export *` so the
package surface is unchanged. Tests that assumed which ids a run would pick read them back from
the queue instead, and pick a task that is due rather than the lowest one present.

### Compatibility

No instruction account list or argument changes, so nothing already queued is affected.

`nextAvailableTaskIds` now requires `capacity`, placed after `random` so a call written against
the previous signature fails rather than comparing ids against a boolean. Consumers in
`helium-program-library` need the argument added; each already has the task queue account in
hand. Queues in use are unaffected either way, their capacities being exact multiples of eight.

Version: `tuktuk` 0.2.7 → 0.2.8. The SDK change wants a minor rather than a patch when these
packages are next released.
