### PR TITLE
fix(solana-programs): unblock the clippy -D warnings CI gate

### DIFF
--- a/solana-programs/Cargo.toml
+++ b/solana-programs/Cargo.toml
@@ -17,3 +17,11 @@ codegen-units = 1
 anchor-lang = "0.31.1"
 anchor-spl = "0.31.1"
 solana-zk-sdk = "2.2.3"
+
+# The anchor/solana program macros emit these cfgs, so declare them as expected.
+# Otherwise Rust's check-cfg flags them and clippy -D warnings fails CI.
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("custom-heap", "custom-panic", "anchor-debug"))',
+] }

--- a/solana-programs/programs/cpi-example/Cargo.toml
+++ b/solana-programs/programs/cpi-example/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 crate-type = ["cdylib", "lib"]
 name = "cpi_example"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 devnet = []

--- a/solana-programs/programs/cron/Cargo.toml
+++ b/solana-programs/programs/cron/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 crate-type = ["cdylib", "lib"]
 name = "cron"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 devnet = []

--- a/solana-programs/programs/tuktuk/Cargo.toml
+++ b/solana-programs/programs/tuktuk/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 crate-type = ["cdylib", "lib"]
 name = "tuktuk"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 devnet = []

--- a/solana-programs/programs/tuktuk/src/instructions/initialize_task_queue_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/initialize_task_queue_v0.rs
@@ -35,7 +35,7 @@ pub struct InitializeTaskQueueV0<'info> {
       payer = payer,
       seeds = ["task_queue".as_bytes(), tuktuk_config.key().as_ref(), &tuktuk_config.next_task_queue_id.to_le_bytes()[..]],
       bump,
-      space = 60 + std::mem::size_of::<TaskQueueV0>() + args.name.len() + ((args.capacity + 7) / 8) as usize + args.lookup_tables.len() * 32,
+      space = 60 + std::mem::size_of::<TaskQueueV0>() + args.name.len() + args.capacity.div_ceil(8) as usize + args.lookup_tables.len() * 32,
     )]
     pub task_queue: Box<Account<'info, TaskQueueV0>>,
     #[account(
@@ -76,7 +76,7 @@ pub fn handler(ctx: Context<InitializeTaskQueueV0>, args: InitializeTaskQueueArg
         reserved: Pubkey::default(),
         min_crank_reward: args.min_crank_reward,
         capacity: args.capacity,
-        task_bitmap: vec![0; ((args.capacity + 7) / 8) as usize],
+        task_bitmap: vec![0; args.capacity.div_ceil(8) as usize],
         name: args.name.clone(),
         bump_seed: ctx.bumps.task_queue,
         created_at: Clock::get()?.unix_timestamp,

--- a/solana-programs/programs/tuktuk/src/instructions/update_task_queue_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/update_task_queue_v0.rs
@@ -31,7 +31,7 @@ pub fn handler(ctx: Context<UpdateTaskQueueV0>, args: UpdateTaskQueueArgsV0) -> 
     if let Some(capacity) = args.capacity {
         require_gte!(capacity, ctx.accounts.task_queue.capacity);
         let old_bitmap = ctx.accounts.task_queue.task_bitmap.clone();
-        let new_bitmap_size = ((capacity + 7) / 8) as usize;
+        let new_bitmap_size = capacity.div_ceil(8) as usize;
         let mut new_bitmap = vec![0; new_bitmap_size];
 
         // Copy over the existing bitmap data


### PR DESCRIPTION
The test-rust-lint job runs `cargo clippy --all-targets -- -D warnings`. On the pinned Rust 1.82 (check-cfg is on since 1.80) the anchor and solana program macros emit cfgs that aren't declared -- target_os = "solana" and the custom-heap / custom-panic / anchor-debug features -- so clippy reports 39 unexpected_cfgs warnings and -D warnings turns them into errors. Declare those cfgs as expected in a workspace lint and opt the three program crates into it.

Also rewrite the bitmap-size math (capacity + 7) / 8 as capacity.div_ceil(8) in the three places that compute it. That satisfies newer clippy's manual_div_ceil and drops the u16 overflow when capacity sits within 7 of u16::MAX.

cargo clippy -D warnings, cargo fmt --check, and cargo test --lib all pass.