### PR TITLE
Keep the devnet deploy to programs that are deployed

### DIFF
--- a/.github/workflows/develop-release-program.yaml
+++ b/.github/workflows/develop-release-program.yaml
@@ -27,11 +27,20 @@ jobs:
         id: list_changed_programs
         run: |
           echo "Detecting changes in programs"
-          # Use git diff to get a list of changed programs and output it as JSON
+          # Use git diff to get a list of changed programs and output it as JSON.
+          # shared-utils is a library, and cpi-example and return-example are fixtures the test
+          # suites run against. None of the three is deployed, so a change to one names no program
+          # to deploy.
           changed_files=$(git diff --name-only ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || github.event.before }} ${{ github.event.after }})
-          changed_programs=($(echo "$changed_files" | grep "^solana-programs/programs/" | grep -v "/shared-utils/" | grep -v "/cpi-example/" | cut -d '/' -f 3 | sort -u))
+          changed_programs=($(echo "$changed_files" | grep "^solana-programs/programs/" | grep -v "/shared-utils/" | grep -v "/cpi-example/" | grep -v "/return-example/" | cut -d '/' -f 3 | sort -u))
           echo "${changed_programs[@]}"
-          json="[$(printf "'%s'", "${changed_programs[@]}" | sed 's/,$//')]"
+          # `printf` prints its format once even with nothing to substitute, so an empty list has
+          # to be spelled out. The jobs below skip on `[]` and not on the `['']` it would produce.
+          if [ ${#changed_programs[@]} -eq 0 ]; then
+            json="[]"
+          else
+            json="[$(printf "'%s'", "${changed_programs[@]}" | sed 's/,$//')]"
+          fi
           echo $json
           echo "programs_with_changes=$json" >> $GITHUB_OUTPUT
   build_programs:


### PR DESCRIPTION
`solana-programs/programs/` holds three things that are not deployed programs: `shared-utils` (a library), and `cpi-example` and `return-example` (fixtures the test suites run against). The changed-program detection in the devnet workflow excluded the first two and not the third, so a commit touching `return-example` built it verified, buffer-deployed it, and opened a devnet upgrade proposal for it.

Excluding the third exposes the empty case, which the JSON construction got wrong. `printf` prints its format once even with nothing to substitute, so an empty list came out as `['']`, and `build_programs` / `publish_programs` skip on `[]`. Left alone, a commit touching only a fixture or a library would have run the matrix with an empty program name instead of skipping.

Measured against the five inputs that matter, running the step's own pipeline:

| changed files | `programs_with_changes` | `build_programs` |
|---|---|---|
| cron + fixtures | `['cron']` | runs |
| `return-example` only | `[]` | skipped |
| `shared-utils` only | `[]` | skipped |
| nothing under `programs/` | `[]` | skipped |
| cron + tuktuk | `['cron','tuktuk']` | runs |

Dropping either guard reproduces its own failure: without the exclusion a `return-example`-only change yields `['return-example']` and runs; without the empty-list guard it yields `['']` and runs.

The workflow parses and the step's shell block is syntax-clean.