### PR TITLE
Bump the versions the publishable artifacts need

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6829,7 +6829,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuktuk-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-program"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anchor-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ itertools = "0.13"
 tokio-graceful-shutdown = "0.15"
 solana-transaction-utils = { version = "0.4.2", path = "./solana-transaction-utils" }
 tuktuk-sdk = { version = "0.4.1", path = "./tuktuk-sdk" }
-tuktuk-program = { version = "0.3.2", path = "./tuktuk-program" }
+tuktuk-program = { version = "0.4.0", path = "./tuktuk-program" }
 solana-account-decoder = { version = "2.2.3" }
 solana-clock = { version = "2.2.1" }
 solana-transaction-status = "2.2.3"

--- a/solana-programs/lerna.json
+++ b/solana-programs/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "0.0.11"
+  "version": "0.1.0"
 }

--- a/solana-programs/packages/cron-sdk/package.json
+++ b/solana-programs/packages/cron-sdk/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0",
     "@helium/anchor-resolvers": "^0.10.0-alpha.4",
-    "@helium/tuktuk-idls": "^0.0.11",
+    "@helium/tuktuk-idls": "^0.1.0",
     "@helium/tuktuk-sdk": "^0.1.0",
     "js-sha256": "^0.11.0"
   },

--- a/solana-programs/packages/cron-sdk/yarn.deploy.lock
+++ b/solana-programs/packages/cron-sdk/yarn.deploy.lock
@@ -90,7 +90,7 @@ __metadata:
   dependencies:
     "@coral-xyz/anchor": ^0.31.0
     "@helium/anchor-resolvers": ^0.10.0-alpha.4
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@helium/tuktuk-sdk": ^0.1.0
     "@types/crypto-js": ^4.1.1
     git-format-staged: ^2.1.3
@@ -101,7 +101,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@helium/tuktuk-idls@^0.0.11":
+"@helium/tuktuk-idls@^0.1.0":
   version: 0.0.0-use.local
   resolution: "@helium/tuktuk-idls@workspace:packages/tuktuk-idls"
   dependencies:
@@ -119,7 +119,7 @@ __metadata:
   dependencies:
     "@coral-xyz/anchor": ^0.31.0
     "@helium/anchor-resolvers": ^0.10.0-alpha.4
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@types/crypto-js": ^4.1.1
     git-format-staged: ^2.1.3
     js-sha256: ^0.11.0

--- a/solana-programs/packages/remote-example-server/package.json
+++ b/solana-programs/packages/remote-example-server/package.json
@@ -36,7 +36,7 @@
     "@coral-xyz/anchor": "^0.31.0",
     "@fastify/cors": "^8.1.1",
     "@helium/spl-utils": "^0.10.3",
-    "@helium/tuktuk-idls": "^0.0.11",
+    "@helium/tuktuk-idls": "^0.1.0",
     "@helium/tuktuk-sdk": "^0.1.0",
     "@solana/spl-token": "^0.3.8",
     "@solana/web3.js": "^1.95.2",

--- a/solana-programs/packages/remote-example-server/yarn.deploy.lock
+++ b/solana-programs/packages/remote-example-server/yarn.deploy.lock
@@ -169,7 +169,7 @@ __metadata:
     "@coral-xyz/anchor": ^0.31.0
     "@fastify/cors": ^8.1.1
     "@helium/spl-utils": ^0.10.3
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@helium/tuktuk-sdk": ^0.1.0
     "@solana/spl-token": ^0.3.8
     "@solana/web3.js": ^1.95.2
@@ -205,7 +205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@helium/tuktuk-idls@^0.0.11":
+"@helium/tuktuk-idls@^0.1.0":
   version: 0.0.0-use.local
   resolution: "@helium/tuktuk-idls@workspace:packages/tuktuk-idls"
   dependencies:
@@ -223,7 +223,7 @@ __metadata:
   dependencies:
     "@coral-xyz/anchor": ^0.31.0
     "@helium/anchor-resolvers": ^0.10.0-alpha.4
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@types/crypto-js": ^4.1.1
     git-format-staged: ^2.1.3
     js-sha256: ^0.11.0

--- a/solana-programs/packages/tuktuk-idls/package.json
+++ b/solana-programs/packages/tuktuk-idls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/tuktuk-idls",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "Exported idls",
   "publishConfig": {
     "access": "public",

--- a/solana-programs/packages/tuktuk-sdk/package.json
+++ b/solana-programs/packages/tuktuk-sdk/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@coral-xyz/anchor": "^0.31.0",
     "@helium/anchor-resolvers": "^0.10.0-alpha.4",
-    "@helium/tuktuk-idls": "^0.0.11",
+    "@helium/tuktuk-idls": "^0.1.0",
     "js-sha256": "^0.11.0"
   },
   "devDependencies": {

--- a/solana-programs/packages/tuktuk-sdk/yarn.deploy.lock
+++ b/solana-programs/packages/tuktuk-sdk/yarn.deploy.lock
@@ -84,7 +84,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@helium/tuktuk-idls@^0.0.11":
+"@helium/tuktuk-idls@^0.1.0":
   version: 0.0.0-use.local
   resolution: "@helium/tuktuk-idls@workspace:packages/tuktuk-idls"
   dependencies:
@@ -102,7 +102,7 @@ __metadata:
   dependencies:
     "@coral-xyz/anchor": ^0.31.0
     "@helium/anchor-resolvers": ^0.10.0-alpha.4
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@types/crypto-js": ^4.1.1
     git-format-staged: ^2.1.3
     js-sha256: ^0.11.0

--- a/solana-programs/yarn.lock
+++ b/solana-programs/yarn.lock
@@ -204,7 +204,7 @@ __metadata:
   dependencies:
     "@coral-xyz/anchor": ^0.31.0
     "@helium/anchor-resolvers": ^0.10.0-alpha.4
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@helium/tuktuk-sdk": ^0.1.0
     "@types/crypto-js": ^4.1.1
     git-format-staged: ^2.1.3
@@ -222,7 +222,7 @@ __metadata:
     "@coral-xyz/anchor": ^0.31.0
     "@fastify/cors": ^8.1.1
     "@helium/spl-utils": ^0.10.3
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@helium/tuktuk-sdk": ^0.1.0
     "@solana/spl-token": ^0.3.8
     "@solana/web3.js": ^1.95.2
@@ -258,7 +258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@helium/tuktuk-idls@^0.0.11, @helium/tuktuk-idls@workspace:packages/tuktuk-idls":
+"@helium/tuktuk-idls@^0.1.0, @helium/tuktuk-idls@workspace:packages/tuktuk-idls":
   version: 0.0.0-use.local
   resolution: "@helium/tuktuk-idls@workspace:packages/tuktuk-idls"
   dependencies:
@@ -276,7 +276,7 @@ __metadata:
   dependencies:
     "@coral-xyz/anchor": ^0.31.0
     "@helium/anchor-resolvers": ^0.10.0-alpha.4
-    "@helium/tuktuk-idls": ^0.0.11
+    "@helium/tuktuk-idls": ^0.1.0
     "@types/crypto-js": ^4.1.1
     git-format-staged: ^2.1.3
     js-sha256: ^0.11.0

--- a/tuktuk-cli/Cargo.toml
+++ b/tuktuk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-cli"
-version = "0.2.14"
+version = "0.2.15"
 description = "A cli for tuktuk"
 homepage.workspace = true
 repository.workspace = true

--- a/tuktuk-program/Cargo.toml
+++ b/tuktuk-program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-program"
-version = "0.3.2"
+version = "0.4.0"
 description = "Raw rust sdk for interacting with the tuktuk program"
 
 authors.workspace = true


### PR DESCRIPTION
Three artifacts changed since their last release tag while still carrying that tag's version, so there is no version to publish them under.

| Artifact | Was | Now | Why |
|---|---|---|---|
| `tuktuk-program` | 0.3.2 | **0.4.0** | vendored cron IDL gained `queue_cron_tasks_v1` and `requeue_cron_task_v1` (additive), and `TaskQueueV0::next_available_task_id` now returns `None` for a bit past the queue's capacity |
| `tuktuk-cli` | 0.2.14 | **0.2.15** | `cron requeue` frees a squatted address in the same transaction as the requeue |
| `lerna.json`, `tuktuk-idls` | 0.0.11 | **0.1.0** | the javascript packages version together, and `tuktuk-sdk` / `cron-sdk` are already 0.1.0 |

The root workspace dependency moves with `tuktuk-program`, and the three `^0.0.11` ranges naming `tuktuk-idls` move to `^0.1.0`. That second part is load-bearing rather than cosmetic: a caret range on a `0.0.x` version matches that version alone, so a range left at `^0.0.11` selects the published package instead of the workspace copy — which both fails an immutable install and, if the lockfile were simply regenerated instead, would quietly build against the released package.

Verified `yarn install --immutable` is clean and the lockfile still records `resolution: "@helium/tuktuk-idls@workspace:packages/tuktuk-idls"` and the same for `tuktuk-sdk`.

Two crates deliberately untouched:

- `tuktuk-sdk` (0.4.1) and `tuktuk-crank-turner` (0.2.27) are already ahead of their tags, so they need a tag rather than a bump.
- `solana-transaction-utils` stays at 0.4.2. Its only change since that tag drops a needless `into_iter()`, so the crate behaves identically and a release would be churn.

Gate: `fmt`, `clippy -D warnings`, unit tests and the doctest all clean in the root workspace and in `solana-programs`.