### PR TITLE
chore: bump tuktuk-sdk to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6903,7 +6903,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-sdk"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ spl-token = "4.0.0"
 itertools = "0.13"
 tokio-graceful-shutdown = "0.15"
 solana-transaction-utils = { version = "0.4.2", path = "./solana-transaction-utils" }
-tuktuk-sdk = { version = "0.4.1", path = "./tuktuk-sdk" }
+tuktuk-sdk = { version = "0.4.2", path = "./tuktuk-sdk" }
 tuktuk-program = { version = "0.4.0", path = "./tuktuk-program" }
 solana-account-decoder = { version = "2.2.3" }
 solana-clock = { version = "2.2.1" }

--- a/tuktuk-sdk/Cargo.toml
+++ b/tuktuk-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-sdk"
-version = "0.4.1"
+version = "0.4.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
tuktuk-sdk 0.4.1 was already published to crates.io on Aug 5 from a local machine, before the signed cron scheduling, task-id exhaustion reporting, and recorded-task gate changes landed. The published 0.4.1 depends on tuktuk-program ^0.3.2, so the current source cannot ship under that version.

Bump to 0.4.2 so the sdk can publish against tuktuk-program 0.4.0, and move the workspace pin with it so tuktuk-cli 0.2.15 resolves to the new sdk rather than the stale published 0.4.1.