### PR TITLE
Install toml-cli against its own lockfile, and refuse an empty program id

### DIFF
--- a/.github/workflows/release-program.yaml
+++ b/.github/workflows/release-program.yaml
@@ -27,7 +27,12 @@ jobs:
           path: |
             ~/.cargo/bin/toml
           key: toml-cli-${{ runner.os }}-v0002
-      - run: (cargo install toml-cli || true)
+      # `--locked` builds against the crate's own lockfile. This step runs in `solana-programs`,
+      # so it takes that directory's pinned toolchain, and re-resolving picks up dependencies
+      # that require a newer rustc than the pin. A failure here is fatal: the next step reads
+      # the program id with this binary, and an empty id reaches `anchor idl write-buffer`
+      # several steps later as a missing argument.
+      - run: cargo install toml-cli --locked
         if: steps.cache-toml-cli.outputs.cache-hit != 'true'
         shell: bash
 
@@ -39,6 +44,14 @@ jobs:
           VERSION=$(echo $TAG | sed 's/.*-\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\)$/\1/')
           PROGRAM_NAME=${PROGRAM//-/_}  # Substitute dashes with underscores
           PROGRAM_ID=$(~/.cargo/bin/toml get Anchor.toml programs.localnet.${PROGRAM_NAME} | tr -d '"')
+
+          # An id is what every step below addresses the program by, and an empty one is accepted
+          # until `anchor idl write-buffer` rejects it as a missing argument, nine minutes and four
+          # steps away from the tag that named no program Anchor.toml holds.
+          if [ -z "$PROGRAM_ID" ]; then
+            echo "::error::no program id for '${PROGRAM_NAME}' in Anchor.toml programs.localnet (tag ${TAG})"
+            exit 1
+          fi
 
           echo "Program: $PROGRAM"
           echo "Program: $PROGRAM_ID"


### PR DESCRIPTION
`program-tuktuk-0.2.8` and `program-cron-0.3.0` both failed, and neither produced a Squads proposal. `program-mini-fanout-0.1.4`, `program-welcome-pack-0.0.4` and `program-hpl-crons-0.1.8` succeeded in the other repo only because their toml-cli cache hit and the install never ran.

## What happened

```
rustc 1.82.0 is not supported by the following package:
  unicode-segmentation@1.13.3 requires rustc 1.85.0
```

This step runs in `solana-programs`, so it takes that directory's pinned toolchain. Re-resolving toml-cli's dependency tree now reaches a crate that wants a newer rustc than the pin allows, so the install fails.

Two things then hid it:

1. The step was written `(cargo install toml-cli || true)`, so it reported **success** with no binary on disk.
2. `PROGRAM_ID=$(~/.cargo/bin/toml get …)` produced an empty string, which nothing checked.

The run died four steps and nine minutes later inside `buffer-deploy`:

```
error: the following required arguments were not provided:
  <PROGRAM_ID>
Usage: anchor idl write-buffer --filepath <FILEPATH> ... <PROGRAM_ID>
```

That message names neither the install nor the tag, which is what made this expensive to read.

## The change

- `cargo install toml-cli --locked` — build what the crate was published with instead of re-resolving.
- Drop `|| true`, so an install failure fails the job.
- Refuse an empty `PROGRAM_ID` where it is read, with a message naming the program and the tag.

## Verified

Reproduced locally under a `rust-toolchain.toml` pinning 1.82.0: the plain install exits 101 with the same error; `--locked` exits 0 and produces the binary. That binary performs the real lookups:

```
programs.localnet.tuktuk = tuktukUrfhXT6ZT77QTU8RQtvgL967uRuVagWF57zVA
programs.localnet.cron   = cronAjRZnJn3MTP3B9kE62NWDrjSuAPVXf9c4hu4grM
```

The guard was exercised both ways — an empty id exits 1 with the error line, a real id passes through. YAML parses.

Once this is in, `program-tuktuk-0.2.8` and `program-cron-0.3.0` need re-cutting to re-trigger the release.