### PR TITLE
Build task-run errors only when they are raised

### DIFF
--- a/.github/workflows/solana-programs.yaml
+++ b/.github/workflows/solana-programs.yaml
@@ -44,7 +44,10 @@ jobs:
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo fmt -- --check
         working-directory: solana-programs
-      - run: cargo clippy --all-targets -- -D warnings -A clippy::result_large_err -A clippy::too_many_arguments -A clippy::uninlined-format-args -A ambiguous_glob_reexports
+      # or_fun_call is on because `ok_or(error!(..))` builds the error on the success path too,
+      # and an AnchorError owns two Strings. The heap a program gets is a bump allocator that
+      # never frees, so errors that are never returned still consume it.
+      - run: cargo clippy --all-targets -- -D warnings -D clippy::or_fun_call -A clippy::result_large_err -A clippy::too_many_arguments -A clippy::uninlined-format-args -A ambiguous_glob_reexports
         working-directory: solana-programs
 
   test-unit:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-utils"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bincode",
  "dashmap",
@@ -6860,7 +6860,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-crank-turner"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ spl-associated-token-account = "6.0.0"
 spl-token = "4.0.0"
 itertools = "0.13"
 tokio-graceful-shutdown = "0.15"
-solana-transaction-utils = { version = "0.4.2", path = "./solana-transaction-utils" }
+solana-transaction-utils = { version = "0.4.3", path = "./solana-transaction-utils" }
 tuktuk-sdk = { version = "0.4.2", path = "./tuktuk-sdk" }
 tuktuk-program = { version = "0.4.0", path = "./tuktuk-program" }
 solana-account-decoder = { version = "2.2.3" }

--- a/solana-programs/Cargo.lock
+++ b/solana-programs/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana-programs/programs/cron/Cargo.toml
+++ b/solana-programs/programs/cron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cron"
-version = "0.3.0"
+version = "0.3.1"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana-programs/programs/cron/src/instructions/initialize_cron_job_v0.rs
+++ b/solana-programs/programs/cron/src/instructions/initialize_cron_job_v0.rs
@@ -192,7 +192,7 @@ pub fn handler(ctx: Context<InitializeCronJobV0>, args: InitializeCronJobArgsV0)
                 .accounts
                 .task_queue
                 .next_available_task_id()
-                .ok_or(error!(ErrorCode::TaskQueueFull))?,
+                .ok_or_else(|| error!(ErrorCode::TaskQueueFull))?,
             description: format!("queue {}", trunc_name),
         },
     )?;

--- a/solana-programs/programs/cron/src/instructions/queue_cron_tasks_v1.rs
+++ b/solana-programs/programs/cron/src/instructions/queue_cron_tasks_v1.rs
@@ -122,7 +122,7 @@ pub fn handler(ctx: Context<QueueCronTasksV1>) -> Result<RunTaskReturnV0> {
     let accounts = ctx
         .remaining_accounts
         .get(..=num_tasks_per_queue_call)
-        .ok_or(error!(ErrorCode::NotEnoughAccounts))?;
+        .ok_or_else(|| error!(ErrorCode::NotEnoughAccounts))?;
     let next_schedule_task = accounts[num_tasks_per_queue_call].key();
 
     let max_num_tasks_remaining = cron_job

--- a/solana-programs/programs/cron/src/schedule.rs
+++ b/solana-programs/programs/cron/src/schedule.rs
@@ -59,18 +59,19 @@ pub fn running_schedule_task(sysvar_instructions: &AccountInfo) -> Result<Pubkey
     Ok(ix
         .accounts
         .get(RUN_TASK_V0_TASK_ACCOUNT)
-        .ok_or(error!(ErrorCode::NotRunningAsScheduledTask))?
+        .ok_or_else(|| error!(ErrorCode::NotRunningAsScheduledTask))?
         .pubkey)
 }
 
 /// The first execution the schedule names strictly after `after`.
 pub fn next_exec_ts(schedule: &str, after: i64) -> Result<i64> {
     let schedule = Schedule::from_str(schedule).map_err(|_| error!(ErrorCode::InvalidSchedule))?;
-    let after = DateTime::from_timestamp(after, 0).ok_or(error!(ErrorCode::InvalidSchedule))?;
+    let after =
+        DateTime::from_timestamp(after, 0).ok_or_else(|| error!(ErrorCode::InvalidSchedule))?;
     schedule
         .next_after(&after)
         .map(|next| next.timestamp())
-        .ok_or(error!(ErrorCode::InvalidSchedule))
+        .ok_or_else(|| error!(ErrorCode::InvalidSchedule))
 }
 
 /// tuktuk caps a task description at 40 bytes, so descriptions carry a truncated name.

--- a/solana-programs/programs/tuktuk/Cargo.toml
+++ b/solana-programs/programs/tuktuk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk"
-version = "0.2.8"
+version = "0.2.9"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana-programs/programs/tuktuk/src/instructions/queue_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/queue_task_v0.rs
@@ -77,7 +77,7 @@ pub fn handler(ctx: Context<QueueTaskV0>, args: QueueTaskArgsV0) -> Result<()> {
     );
     let crank_reward = args
         .crank_reward
-        .unwrap_or(task_queue.header().min_crank_reward);
+        .unwrap_or_else(|| task_queue.header().min_crank_reward);
     require_gte!(crank_reward, task_queue.header().min_crank_reward);
 
     let mut transaction = args.transaction;

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -251,7 +251,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         // tasks are going to be appended at all. The heap never hands a reservation back.
         let program_id = remaining_accounts
             .get(ix.program_id_index as usize)
-            .ok_or(error!(ErrorCode::InvalidAccountIndex))?
+            .ok_or_else(|| error!(ErrorCode::InvalidAccountIndex))?
             .key;
         let takes_free_tasks = *program_id != MEMO_PROGRAM_ID;
         let capacity = ix.accounts.len().min(remaining_accounts.len())
@@ -270,7 +270,7 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             // turner chooses, so neither side of this bound is fixed by the program.
             let mut acct = remaining_accounts
                 .get(*i as usize)
-                .ok_or(error!(ErrorCode::InvalidAccountIndex))?
+                .ok_or_else(|| error!(ErrorCode::InvalidAccountIndex))?
                 .clone();
             // A task may only sign for this queue's own `b"custom"` PDAs. Signer privilege is
             // never inherited from the outer transaction: the crank turner is an arbitrary,
@@ -585,7 +585,7 @@ pub fn handler<'info>(
             // and can place this instruction first.
             let verify_ix_index = ix_index
                 .checked_sub(1)
-                .ok_or(error!(ErrorCode::MalformedRemoteTransaction))?;
+                .ok_or_else(|| error!(ErrorCode::MalformedRemoteTransaction))?;
             let ix: Instruction = load_instruction_at_checked(
                 verify_ix_index as usize,
                 &ctx.accounts.sysvar_instructions,

--- a/solana-transaction-utils/Cargo.toml
+++ b/solana-transaction-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-transaction-utils"
-version = "0.4.2"
+version = "0.4.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/solana-transaction-utils/src/priority_fee.rs
+++ b/solana-transaction-utils/src/priority_fee.rs
@@ -15,6 +15,25 @@ use crate::error::Error;
 pub const MAX_RECENT_PRIORITY_FEE_ACCOUNTS: usize = 128;
 pub const MIN_PRIORITY_FEE: u64 = 1;
 
+/// The most compute units a transaction may be granted. Asking for more is clamped to this
+/// silently, so a request is capped here instead of relying on that.
+pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+/// Margin over what a simulation measured.
+pub const COMPUTE_MARGIN: f64 = 1.2;
+
+/// The compute budget to request for work a simulation measured at `units_consumed`.
+///
+/// `None` is not a measurement of zero: it means the simulation reported no consumption, so the
+/// whole budget is asked for rather than a margin over nothing.
+pub fn compute_budget_from_simulation(units_consumed: Option<u64>) -> u32 {
+    let Some(measured) = units_consumed else {
+        return MAX_COMPUTE_UNIT_LIMIT;
+    };
+
+    ((measured as f64 * COMPUTE_MARGIN) as u64).min(MAX_COMPUTE_UNIT_LIMIT as u64) as u32
+}
+
 pub async fn get_estimate<C: AsRef<RpcClient>>(
     client: &C,
     accounts: &[Pubkey],
@@ -102,7 +121,7 @@ pub async fn compute_budget_for_instructions<C: AsRef<RpcClient>>(
                     .first()
         {
             ix.data = solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(
-                1900000,
+                MAX_COMPUTE_UNIT_LIMIT,
             )
             .data; // Replace limit
             has_compute_budget = true;
@@ -114,7 +133,9 @@ pub async fn compute_budget_for_instructions<C: AsRef<RpcClient>>(
         // Prepend compute budget instruction if none was found
         updated_instructions.insert(
             0,
-            solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1900000),
+            solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(
+                MAX_COMPUTE_UNIT_LIMIT,
+            ),
         );
     }
 
@@ -145,12 +166,19 @@ pub async fn compute_budget_for_instructions<C: AsRef<RpcClient>>(
 
     // Simulate the transaction to get the actual compute used
     let simulation_result = client.as_ref().simulate_transaction(&snub_tx).await?;
-    if simulation_result.value.err.is_some() {
-        info!(?simulation_result.value.logs, "simulation error");
-    }
-    let actual_compute_used = simulation_result.value.units_consumed.unwrap_or(1000000);
-
-    let final_compute_budget = (actual_compute_used as f32 * compute_multiplier) as u32;
+    // A simulation that failed stopped partway, so what it consumed is not a measurement of the
+    // work: scaling it produces a budget too small for the transaction it is about to be spent on.
+    let final_compute_budget = if let Some(err) = &simulation_result.value.err {
+        info!(?err, ?simulation_result.value.logs, "simulation error");
+        MAX_COMPUTE_UNIT_LIMIT
+    } else {
+        let measured = simulation_result
+            .value
+            .units_consumed
+            .unwrap_or(MAX_COMPUTE_UNIT_LIMIT as u64);
+        ((measured as f64 * compute_multiplier as f64) as u64).min(MAX_COMPUTE_UNIT_LIMIT as u64)
+            as u32
+    };
     Ok((
         compute_budget_instruction(final_compute_budget),
         final_compute_budget,
@@ -248,4 +276,38 @@ pub async fn auto_compute_limit_and_price<C: AsRef<RpcClient>>(
     }
 
     auto_compute_price(client, &updated_instructions, payer, compute_limit).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_budget_leaves_the_margin_above_what_was_measured() {
+        // Measured against live traffic: a delegation claim simulates around 410,000 and the
+        // budget granted for it sits around 490,000, which is the margin and nothing else.
+        let budget = compute_budget_from_simulation(Some(410_000));
+        assert_eq!(budget, 492_000);
+        assert!(budget > 410_000);
+    }
+
+    #[test]
+    fn nothing_measured_asks_for_the_whole_budget() {
+        assert_eq!(compute_budget_from_simulation(None), MAX_COMPUTE_UNIT_LIMIT);
+    }
+
+    #[test]
+    fn a_budget_never_exceeds_what_a_transaction_may_be_granted() {
+        for measured in [
+            MAX_COMPUTE_UNIT_LIMIT as u64,
+            MAX_COMPUTE_UNIT_LIMIT as u64 * 2,
+            u64::MAX,
+        ] {
+            assert_eq!(
+                compute_budget_from_simulation(Some(measured)),
+                MAX_COMPUTE_UNIT_LIMIT,
+                "measured {measured} was not capped"
+            );
+        }
+    }
 }

--- a/solana-transaction-utils/src/priority_fee.rs
+++ b/solana-transaction-utils/src/priority_fee.rs
@@ -27,11 +27,16 @@ pub const COMPUTE_MARGIN: f64 = 1.2;
 /// `None` is not a measurement of zero: it means the simulation reported no consumption, so the
 /// whole budget is asked for rather than a margin over nothing.
 pub fn compute_budget_from_simulation(units_consumed: Option<u64>) -> u32 {
+    compute_budget_from_simulation_with_margin(units_consumed, COMPUTE_MARGIN)
+}
+
+/// Same policy with a caller-chosen margin.
+pub fn compute_budget_from_simulation_with_margin(units_consumed: Option<u64>, margin: f64) -> u32 {
     let Some(measured) = units_consumed else {
         return MAX_COMPUTE_UNIT_LIMIT;
     };
 
-    ((measured as f64 * COMPUTE_MARGIN) as u64).min(MAX_COMPUTE_UNIT_LIMIT as u64) as u32
+    ((measured as f64 * margin) as u64).min(MAX_COMPUTE_UNIT_LIMIT as u64) as u32
 }
 
 pub async fn get_estimate<C: AsRef<RpcClient>>(
@@ -172,12 +177,10 @@ pub async fn compute_budget_for_instructions<C: AsRef<RpcClient>>(
         info!(?err, ?simulation_result.value.logs, "simulation error");
         MAX_COMPUTE_UNIT_LIMIT
     } else {
-        let measured = simulation_result
-            .value
-            .units_consumed
-            .unwrap_or(MAX_COMPUTE_UNIT_LIMIT as u64);
-        ((measured as f64 * compute_multiplier as f64) as u64).min(MAX_COMPUTE_UNIT_LIMIT as u64)
-            as u32
+        compute_budget_from_simulation_with_margin(
+            simulation_result.value.units_consumed,
+            compute_multiplier as f64,
+        )
     };
     Ok((
         compute_budget_instruction(final_compute_budget),
@@ -289,6 +292,19 @@ mod tests {
         let budget = compute_budget_from_simulation(Some(410_000));
         assert_eq!(budget, 492_000);
         assert!(budget > 410_000);
+    }
+
+    #[test]
+    fn a_caller_chosen_margin_is_honoured() {
+        assert_eq!(
+            compute_budget_from_simulation_with_margin(Some(100_000), 1.5),
+            150_000
+        );
+        // The default is the same policy with the shared margin.
+        assert_eq!(
+            compute_budget_from_simulation(Some(100_000)),
+            compute_budget_from_simulation_with_margin(Some(100_000), COMPUTE_MARGIN)
+        );
     }
 
     #[test]

--- a/solana-transaction-utils/src/queue.rs
+++ b/solana-transaction-utils/src/queue.rs
@@ -20,7 +20,9 @@ use tracing::info;
 use crate::{
     error::Error,
     pack::{PackedTransaction, MAX_TRANSACTION_SIZE},
-    priority_fee::{auto_compute_price, compute_budget_instruction},
+    priority_fee::{
+        auto_compute_price, compute_budget_from_simulation, compute_budget_instruction,
+    },
     sender::PackedTransactionWithTasks,
 };
 
@@ -115,9 +117,7 @@ pub async fn create_transaction_queue<T: Send + Clone + 'static + Sync>(
                 info!(?err, ?sim_result.value.logs, "simulation error");
             }
 
-            // Scale up by 1.2 just to be sure it'll succeed.
-            let compute_units =
-                (sim_result.value.units_consumed.unwrap_or(1000000) as f64 * 1.2) as u32;
+            let compute_units = compute_budget_from_simulation(sim_result.value.units_consumed);
             let mut updated_instructions = bundle.tx.instructions.clone();
             let compute_budget_ix = compute_budget_instruction(compute_units);
             // Replace or insert compute budget instruction

--- a/solana-transaction-utils/src/queue.rs
+++ b/solana-transaction-utils/src/queue.rs
@@ -97,6 +97,7 @@ pub async fn create_transaction_queue<T: Send + Clone + 'static + Sync>(
         Result<(Vec<Instruction>, Option<TransactionError>, u64), Error>,
     ) {
         let tasks = bundle.tasks;
+        let task_count = tasks.len();
         let result = async {
             let blockhash = rpc_client.get_latest_blockhash().await?;
             let message = v0::Message::try_compile(
@@ -118,6 +119,15 @@ pub async fn create_transaction_queue<T: Send + Clone + 'static + Sync>(
             }
 
             let compute_units = compute_budget_from_simulation(sim_result.value.units_consumed);
+            // The measurement is the only record of why a budget was what it was. A transaction
+            // that later runs out of compute cannot be explained without it, and a simulation that
+            // succeeded used to leave nothing behind at all.
+            info!(
+                measured = ?sim_result.value.units_consumed,
+                budget = compute_units,
+                tasks = task_count,
+                "compute budget from simulation"
+            );
             let mut updated_instructions = bundle.tx.instructions.clone();
             let compute_budget_ix = compute_budget_instruction(compute_units);
             // Replace or insert compute budget instruction

--- a/tuktuk-cli/src/cmd/task.rs
+++ b/tuktuk-cli/src/cmd/task.rs
@@ -136,7 +136,7 @@ async fn simulate_task(client: &CliClient, task_key: Pubkey) -> Result<Option<Si
             // Create and simulate the transaction
             let mut updated_instructions = vec![
                 solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(
-                    1900000,
+                    solana_transaction_utils::priority_fee::MAX_COMPUTE_UNIT_LIMIT,
                 ),
             ];
             updated_instructions.extend(run_ix.instructions.clone());

--- a/tuktuk-crank-turner/Cargo.toml
+++ b/tuktuk-crank-turner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-crank-turner"
-version = "0.2.28"
+version = "0.2.29"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
`error!()` allocates. An `AnchorError` owns its name and message as `String`s, so passing
it to `ok_or` builds one on every call, including the calls that succeed. The SBF heap is
a 32KB bump allocator whose `dealloc` is a no-op, so those discarded errors stay allocated
for the rest of the instruction.

The site that matters is the per-account loop in `run_task_v0`. A task's transaction holds
one index per account per instruction, so the recurring end-of-epoch task, which names 30
accounts across 5 instructions, builds 73 errors it never returns and runs the heap dry
partway through the fifth instruction.

Driving that task through an in-process SVM, with its accounts and every program it reaches
taken from mainnet:

| tuktuk | outcome |
| --- | --- |
| 0.2.7 | ok, 516,152 CU |
| 0.2.8 | `memory allocation failed, out of memory` at 376,441 CU |
| this branch | ok, 511,701 CU |

Reverting the one line in the same tree brings the OOM back at the same CU, and the run is
now cheaper than 0.2.7 because it no longer builds errors it discards.

The remaining seven sites are one per instruction or one per run rather than one per
account, so none of them is load-bearing on its own; they move for the same reason.

A task whose run fails is never marked complete, so it stays queued and is retried. The
crank turner does not submit a transaction whose simulation failed, which is why this left
no failed transaction on chain to look at.
