### PR TITLE
Bump tuktuk-cli to 0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6829,7 +6829,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuktuk-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anchor-client",
  "anchor-lang",

--- a/tuktuk-cli/Cargo.toml
+++ b/tuktuk-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk-cli"
-version = "0.2.15"
+version = "0.2.16"
 description = "A cli for tuktuk"
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
`tuktuk-cli` 0.2.15 is the version on crates.io, and #103 changed `cmd/task.rs` without bumping it,
so the change has no version to publish under.

The change itself is inert on the wire: simulating a task asked for 1,900,000 compute units, above
the 1,400,000 a transaction may be granted, and requests above that are clamped. It now asks for
the ceiling by name.

`solana-transaction-utils` and `tuktuk-crank-turner` were bumped in #103; this is the one that was
missed.
