### PR TITLE
Read return data only from the program the run invoked

### DIFF
--- a/program-tests/Cargo.lock
+++ b/program-tests/Cargo.lock
@@ -828,6 +828,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpi-example"
+version = "0.1.0"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "getrandom 0.2.17",
+ "solana-zk-sdk",
+ "tuktuk-program",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5317,7 +5328,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuktuk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -5338,6 +5349,7 @@ name = "tuktuk-program-tests"
 version = "0.0.0"
 dependencies = [
  "anchor-lang",
+ "cpi-example",
  "litesvm",
  "return-example",
  "solana-sdk",

--- a/program-tests/Cargo.lock
+++ b/program-tests/Cargo.lock
@@ -5317,7 +5317,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuktuk"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/program-tests/Cargo.toml
+++ b/program-tests/Cargo.toml
@@ -13,6 +13,9 @@ tuktuk = { path = "../solana-programs/programs/tuktuk", features = ["no-entrypoi
 return-example = { path = "../solana-programs/programs/return-example", features = [
   "no-entrypoint",
 ] }
+cpi-example = { path = "../solana-programs/programs/cpi-example", features = [
+  "no-entrypoint",
+] }
 anchor-lang = "=0.31.1"
 litesvm = "0.6"
 solana-sdk = "2.2"

--- a/program-tests/tests/run_task.rs
+++ b/program-tests/tests/run_task.rs
@@ -555,6 +555,61 @@ fn a_tasks_account_the_instruction_did_not_name_is_not_read() {
 }
 
 #[test]
+fn return_data_that_is_not_a_task_return_leaves_the_run_alone() {
+    let mut ctx = setup(100, 10_000, 100_000);
+
+    let artifact = std::path::Path::new(&so_path())
+        .parent()
+        .expect("the built program has a directory")
+        .join("return_example.so");
+    let program = std::fs::read(&artifact).unwrap_or_else(|e| {
+        panic!("read {artifact:?} ({e}); run `anchor build` in solana-programs/")
+    });
+    ctx.svm.add_program(return_example::ID, &program);
+
+    // The invoked instruction returns a bool, so the slot the run reads holds one byte: too
+    // short to be a task return, and named for the instruction's own caller rather than for
+    // the run. This is the shape a nested call leaves behind, and the run has no task list to
+    // act on either way.
+    let transaction = CompiledTransactionV0 {
+        num_rw_signers: 0,
+        num_ro_signers: 0,
+        num_rw: 0,
+        accounts: vec![system_program::ID, return_example::ID],
+        instructions: vec![CompiledInstructionV0 {
+            program_id_index: 1,
+            accounts: vec![0],
+            data: return_example::instruction::ReturnNonTaskData.data(),
+        }],
+        signer_seeds: vec![],
+    };
+    queue(&mut ctx, 0, TriggerV0::Now, transaction, 0).expect("queue the task");
+
+    let turner = ctx.turner();
+    let (task, _) = task_pda(&ctx.task_queue, 0);
+    let result = run_task_named(
+        &mut ctx,
+        0,
+        &turner,
+        vec![
+            AccountMeta::new_readonly(system_program::ID, false),
+            AccountMeta::new_readonly(return_example::ID, false),
+        ],
+        vec![],
+        vec![],
+    );
+    assert!(
+        result.is_ok(),
+        "a run whose instruction left non-task return data should still complete: {:?}",
+        result.err().map(|e| e.err)
+    );
+    assert!(
+        !task_account_exists(&ctx.svm, &task),
+        "the task should have been closed by the run"
+    );
+}
+
+#[test]
 fn a_matching_free_task_account_creates_the_child() {
     let mut ctx = setup(100, 10_000, 100_000);
     let _ = queue(&mut ctx, 0, TriggerV0::Now, returns(vec![child(None)]), 1)

--- a/program-tests/tests/run_task.rs
+++ b/program-tests/tests/run_task.rs
@@ -388,6 +388,18 @@ fn run_task_named(
     ctx.svm.send_transaction(tx)
 }
 
+/// Load one of the fixture programs built alongside tuktuk into the SVM.
+fn add_fixture(ctx: &mut Ctx, program_id: Pubkey, file: &str) {
+    let artifact = std::path::Path::new(&so_path())
+        .parent()
+        .expect("the built program has a directory")
+        .join(file);
+    let program = std::fs::read(&artifact).unwrap_or_else(|e| {
+        panic!("read {artifact:?} ({e}); run `anchor build` in solana-programs/")
+    });
+    ctx.svm.add_program(program_id, &program);
+}
+
 /// Queue a task that hands one child back through an account the returning program owns, the
 /// child carrying `payload_len` bytes. Returns the accounts that task names.
 fn queue_returning_task(
@@ -396,14 +408,7 @@ fn queue_returning_task(
     free_tasks: u8,
     names: Vec<u8>,
 ) -> Vec<AccountMeta> {
-    let artifact = std::path::Path::new(&so_path())
-        .parent()
-        .expect("the built program has a directory")
-        .join("return_example.so");
-    let program = std::fs::read(&artifact).unwrap_or_else(|e| {
-        panic!("read {artifact:?} ({e}); run `anchor build` in solana-programs/")
-    });
-    ctx.svm.add_program(return_example::ID, &program);
+    add_fixture(ctx, return_example::ID, "return_example.so");
 
     let (queue_authority, _) =
         Pubkey::find_program_address(&[b"queue_authority"], &return_example::ID);
@@ -554,23 +559,120 @@ fn a_tasks_account_the_instruction_did_not_name_is_not_read() {
     );
 }
 
+/// Queue a task whose instruction is `return_example::call_then_return_nothing`, invoking
+/// `cpi_example` with `nested_data` and returning nothing of its own.
+fn queue_nested_returning_task(ctx: &mut Ctx, id: u16, nested_data: Vec<u8>, free_tasks: u8) {
+    add_fixture(ctx, return_example::ID, "return_example.so");
+    add_fixture(ctx, cpi_example::ID, "cpi_example.so");
+
+    let transaction = CompiledTransactionV0 {
+        num_rw_signers: 0,
+        num_ro_signers: 0,
+        num_rw: 0,
+        accounts: vec![system_program::ID, cpi_example::ID, return_example::ID],
+        instructions: vec![CompiledInstructionV0 {
+            program_id_index: 2,
+            accounts: vec![0, 1],
+            data: return_example::instruction::CallThenReturnNothing { data: nested_data }.data(),
+        }],
+        signer_seeds: vec![],
+    };
+    queue(ctx, id, TriggerV0::Now, transaction, free_tasks).expect("queue the task");
+}
+
+fn nested_accounts() -> Vec<AccountMeta> {
+    vec![
+        AccountMeta::new_readonly(system_program::ID, false),
+        AccountMeta::new_readonly(cpi_example::ID, false),
+        AccountMeta::new_readonly(return_example::ID, false),
+    ]
+}
+
 #[test]
-fn return_data_that_is_not_a_task_return_leaves_the_run_alone() {
+fn a_nested_calls_return_data_is_not_read_as_a_task_return() {
     let mut ctx = setup(100, 10_000, 100_000);
+    // cpi_example returns a bool, so the slot the run reads holds one byte set by a program the
+    // run did not invoke.
+    queue_nested_returning_task(
+        &mut ctx,
+        0,
+        cpi_example::instruction::ReturnNonTaskData.data(),
+        0,
+    );
 
-    let artifact = std::path::Path::new(&so_path())
-        .parent()
-        .expect("the built program has a directory")
-        .join("return_example.so");
-    let program = std::fs::read(&artifact).unwrap_or_else(|e| {
-        panic!("read {artifact:?} ({e}); run `anchor build` in solana-programs/")
-    });
-    ctx.svm.add_program(return_example::ID, &program);
+    let turner = ctx.turner();
+    let (task, _) = task_pda(&ctx.task_queue, 0);
+    let queue_before = lamports(&ctx.svm, &ctx.task_queue);
+    let result = run_task_named(&mut ctx, 0, &turner, nested_accounts(), vec![], vec![]);
 
-    // The invoked instruction returns a bool, so the slot the run reads holds one byte: too
-    // short to be a task return, and named for the instruction's own caller rather than for
-    // the run. This is the shape a nested call leaves behind, and the run has no task list to
-    // act on either way.
+    assert!(
+        result.is_ok(),
+        "a nested call's return data should not fail the run: {:?}",
+        result.err().map(|e| e.err)
+    );
+    assert!(
+        !task_account_exists(&ctx.svm, &task),
+        "the task should have been closed by the run"
+    );
+    assert_eq!(
+        lamports(&ctx.svm, &ctx.task_queue),
+        queue_before,
+        "no child was funded, so the queue should have spent nothing"
+    );
+}
+
+#[test]
+fn a_nested_calls_task_return_is_not_queued() {
+    let mut ctx = setup(100, 10_000, 100_000);
+    // cpi_example hands back a real child. It is not the program the run invoked, so the child
+    // is not the run's to create even though the bytes deserialize.
+    queue_nested_returning_task(
+        &mut ctx,
+        0,
+        cpi_example::instruction::ReturnTask {
+            args: cpi_example::ReturnTaskArgsV0 { crank_reward: None },
+        }
+        .data(),
+        1,
+    );
+
+    let turner = ctx.turner();
+    // A free task id and its account are supplied, so the only thing between the returned child
+    // and a task account is the check this asserts.
+    let (child, _) = task_pda(&ctx.task_queue, 1);
+    let queue_before = lamports(&ctx.svm, &ctx.task_queue);
+    let result = run_task_named(
+        &mut ctx,
+        0,
+        &turner,
+        nested_accounts(),
+        vec![1],
+        vec![child],
+    );
+
+    assert!(
+        result.is_ok(),
+        "run failed: {:?}",
+        result.err().map(|e| e.err)
+    );
+    assert!(
+        !task_account_exists(&ctx.svm, &child),
+        "a child named by a program the run did not invoke should not be created"
+    );
+    assert_eq!(
+        lamports(&ctx.svm, &ctx.task_queue),
+        queue_before,
+        "no child was created, so the queue should have spent nothing"
+    );
+}
+
+#[test]
+fn a_programs_own_return_data_that_is_not_a_task_return_fails_the_run() {
+    let mut ctx = setup(100, 10_000, 100_000);
+    add_fixture(&mut ctx, return_example::ID, "return_example.so");
+
+    // The invoked program returns the bool itself, so the slot is its own and one byte cannot be
+    // read as a task return.
     let transaction = CompiledTransactionV0 {
         num_rw_signers: 0,
         num_ro_signers: 0,
@@ -598,14 +700,62 @@ fn return_data_that_is_not_a_task_return_leaves_the_run_alone() {
         vec![],
         vec![],
     );
+
     assert!(
-        result.is_ok(),
-        "a run whose instruction left non-task return data should still complete: {:?}",
-        result.err().map(|e| e.err)
+        result.is_err(),
+        "the invoked program's own unreadable return data should fail the run"
     );
     assert!(
-        !task_account_exists(&ctx.svm, &task),
-        "the task should have been closed by the run"
+        task_account_exists(&ctx.svm, &task),
+        "a failed run leaves the task queued"
+    );
+}
+
+#[test]
+fn a_task_return_followed_by_trailing_bytes_fails_the_run() {
+    let mut ctx = setup(100, 10_000, 100_000);
+    add_fixture(&mut ctx, return_example::ID, "return_example.so");
+
+    // An empty task return is eight zero bytes. Anything after them is not part of the value, so
+    // these bytes are a task return only if the read stops before reaching the end of the slot.
+    let mut data = vec![0u8; 8];
+    data.extend_from_slice(&[0xff; 16]);
+
+    let transaction = CompiledTransactionV0 {
+        num_rw_signers: 0,
+        num_ro_signers: 0,
+        num_rw: 0,
+        accounts: vec![system_program::ID, return_example::ID],
+        instructions: vec![CompiledInstructionV0 {
+            program_id_index: 1,
+            accounts: vec![0],
+            data: return_example::instruction::SetRawReturnData { data }.data(),
+        }],
+        signer_seeds: vec![],
+    };
+    queue(&mut ctx, 0, TriggerV0::Now, transaction, 0).expect("queue the task");
+
+    let turner = ctx.turner();
+    let (task, _) = task_pda(&ctx.task_queue, 0);
+    let result = run_task_named(
+        &mut ctx,
+        0,
+        &turner,
+        vec![
+            AccountMeta::new_readonly(system_program::ID, false),
+            AccountMeta::new_readonly(return_example::ID, false),
+        ],
+        vec![],
+        vec![],
+    );
+
+    assert!(
+        result.is_err(),
+        "a value the run only reaches by stopping short of the slot's end is not a task return"
+    );
+    assert!(
+        task_account_exists(&ctx.svm, &task),
+        "a failed run leaves the task queued"
     );
 }
 

--- a/program-tests/tests/run_task.rs
+++ b/program-tests/tests/run_task.rs
@@ -759,6 +759,102 @@ fn a_task_return_followed_by_trailing_bytes_fails_the_run() {
     );
 }
 
+/// Queue a task whose instruction is `cpi_example::return_task`, invoked directly so the child
+/// it names is the run's to create, declaring `free_tasks` children.
+fn queue_child_returning_task(ctx: &mut Ctx, id: u16, free_tasks: u8) {
+    add_fixture(ctx, cpi_example::ID, "cpi_example.so");
+
+    let transaction = CompiledTransactionV0 {
+        num_rw_signers: 0,
+        num_ro_signers: 0,
+        num_rw: 0,
+        accounts: vec![system_program::ID, cpi_example::ID],
+        instructions: vec![CompiledInstructionV0 {
+            program_id_index: 1,
+            accounts: vec![0],
+            data: cpi_example::instruction::ReturnTask {
+                args: cpi_example::ReturnTaskArgsV0 { crank_reward: None },
+            }
+            .data(),
+        }],
+        signer_seeds: vec![],
+    };
+    queue(ctx, id, TriggerV0::Now, transaction, free_tasks).expect("queue the task");
+}
+
+fn child_returning_accounts() -> Vec<AccountMeta> {
+    vec![
+        AccountMeta::new_readonly(system_program::ID, false),
+        AccountMeta::new_readonly(cpi_example::ID, false),
+    ]
+}
+
+#[test]
+fn a_child_returned_beyond_the_declared_count_fails_the_run() {
+    let mut ctx = setup(100, 10_000, 100_000);
+    // The task declares no children, so there is no id for the one its program names.
+    queue_child_returning_task(&mut ctx, 0, 0);
+
+    let turner = ctx.turner();
+    let (task, _) = task_pda(&ctx.task_queue, 0);
+    let result = run_task_named(
+        &mut ctx,
+        0,
+        &turner,
+        child_returning_accounts(),
+        vec![],
+        vec![],
+    );
+
+    assert_eq!(
+        refusal(&result),
+        code(tuktuk::error::ErrorCode::TooManyReturnedTasks),
+        "a child the task reserved no room for should fail the run rather than be dropped"
+    );
+    assert!(
+        task_account_exists(&ctx.svm, &task),
+        "a failed run leaves the task queued"
+    );
+}
+
+#[test]
+fn a_free_task_id_already_in_use_fails_the_run() {
+    let mut ctx = setup(100, 10_000, 100_000);
+    queue_child_returning_task(&mut ctx, 0, 1);
+    // Id 1's account is the one the child would be written into, and it already holds a task.
+    queue_child_returning_task(&mut ctx, 1, 0);
+
+    let turner = ctx.turner();
+    let (task, _) = task_pda(&ctx.task_queue, 0);
+    let (occupied, _) = task_pda(&ctx.task_queue, 1);
+    assert!(
+        task_account_exists(&ctx.svm, &occupied),
+        "the fixture needs id 1 already in use"
+    );
+
+    let result = run_task_named(
+        &mut ctx,
+        0,
+        &turner,
+        child_returning_accounts(),
+        vec![1],
+        vec![occupied],
+    );
+
+    // The bitmap already marks id 1 as in use, and that is refused before the account behind it
+    // is read -- so `FreeTaskAccountNotEmpty` guards only the inverse state, an occupied account
+    // whose bit is clear, which no path produces.
+    assert_eq!(
+        refusal(&result),
+        code(tuktuk::error::ErrorCode::TaskIdAlreadyInUse),
+        "a free-task id the queue already records as in use should fail the run"
+    );
+    assert!(
+        task_account_exists(&ctx.svm, &task),
+        "a failed run leaves the task queued"
+    );
+}
+
 #[test]
 fn a_matching_free_task_account_creates_the_child() {
     let mut ctx = setup(100, 10_000, 100_000);

--- a/program-tests/tests/run_task.rs
+++ b/program-tests/tests/run_task.rs
@@ -565,18 +565,11 @@ fn queue_nested_returning_task(ctx: &mut Ctx, id: u16, nested_data: Vec<u8>, fre
     add_fixture(ctx, return_example::ID, "return_example.so");
     add_fixture(ctx, cpi_example::ID, "cpi_example.so");
 
-    let transaction = CompiledTransactionV0 {
-        num_rw_signers: 0,
-        num_ro_signers: 0,
-        num_rw: 0,
-        accounts: vec![system_program::ID, cpi_example::ID, return_example::ID],
-        instructions: vec![CompiledInstructionV0 {
-            program_id_index: 2,
-            accounts: vec![0, 1],
-            data: return_example::instruction::CallThenReturnNothing { data: nested_data }.data(),
-        }],
-        signer_seeds: vec![],
-    };
+    let transaction = compile_readonly(
+        return_example::ID,
+        &[system_program::ID, cpi_example::ID],
+        return_example::instruction::CallThenReturnNothing { data: nested_data }.data(),
+    );
     queue(ctx, id, TriggerV0::Now, transaction, free_tasks).expect("queue the task");
 }
 
@@ -673,18 +666,11 @@ fn a_programs_own_return_data_that_is_not_a_task_return_fails_the_run() {
 
     // The invoked program returns the bool itself, so the slot is its own and one byte cannot be
     // read as a task return.
-    let transaction = CompiledTransactionV0 {
-        num_rw_signers: 0,
-        num_ro_signers: 0,
-        num_rw: 0,
-        accounts: vec![system_program::ID, return_example::ID],
-        instructions: vec![CompiledInstructionV0 {
-            program_id_index: 1,
-            accounts: vec![0],
-            data: return_example::instruction::ReturnNonTaskData.data(),
-        }],
-        signer_seeds: vec![],
-    };
+    let transaction = compile_readonly(
+        return_example::ID,
+        &[system_program::ID],
+        return_example::instruction::ReturnNonTaskData.data(),
+    );
     queue(&mut ctx, 0, TriggerV0::Now, transaction, 0).expect("queue the task");
 
     let turner = ctx.turner();
@@ -721,18 +707,11 @@ fn a_task_return_followed_by_trailing_bytes_fails_the_run() {
     let mut data = vec![0u8; 8];
     data.extend_from_slice(&[0xff; 16]);
 
-    let transaction = CompiledTransactionV0 {
-        num_rw_signers: 0,
-        num_ro_signers: 0,
-        num_rw: 0,
-        accounts: vec![system_program::ID, return_example::ID],
-        instructions: vec![CompiledInstructionV0 {
-            program_id_index: 1,
-            accounts: vec![0],
-            data: return_example::instruction::SetRawReturnData { data }.data(),
-        }],
-        signer_seeds: vec![],
-    };
+    let transaction = compile_readonly(
+        return_example::ID,
+        &[system_program::ID],
+        return_example::instruction::SetRawReturnData { data }.data(),
+    );
     queue(&mut ctx, 0, TriggerV0::Now, transaction, 0).expect("queue the task");
 
     let turner = ctx.turner();
@@ -764,21 +743,14 @@ fn a_task_return_followed_by_trailing_bytes_fails_the_run() {
 fn queue_child_returning_task(ctx: &mut Ctx, id: u16, free_tasks: u8) {
     add_fixture(ctx, cpi_example::ID, "cpi_example.so");
 
-    let transaction = CompiledTransactionV0 {
-        num_rw_signers: 0,
-        num_ro_signers: 0,
-        num_rw: 0,
-        accounts: vec![system_program::ID, cpi_example::ID],
-        instructions: vec![CompiledInstructionV0 {
-            program_id_index: 1,
-            accounts: vec![0],
-            data: cpi_example::instruction::ReturnTask {
-                args: cpi_example::ReturnTaskArgsV0 { crank_reward: None },
-            }
-            .data(),
-        }],
-        signer_seeds: vec![],
-    };
+    let transaction = compile_readonly(
+        cpi_example::ID,
+        &[system_program::ID],
+        cpi_example::instruction::ReturnTask {
+            args: cpi_example::ReturnTaskArgsV0 { crank_reward: None },
+        }
+        .data(),
+    );
     queue(ctx, id, TriggerV0::Now, transaction, free_tasks).expect("queue the task");
 }
 

--- a/solana-programs/Cargo.lock
+++ b/solana-programs/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "tuktuk"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana-programs/programs/cpi-example/src/lib.rs
+++ b/solana-programs/programs/cpi-example/src/lib.rs
@@ -219,6 +219,13 @@ pub mod cpi_example {
         })
     }
 
+    /// Returns a value that is not a task return. Reached as the nested call of another
+    /// program's instruction, this is what leaves the return-data slot holding bytes named for
+    /// a caller other than the run.
+    pub fn return_non_task_data(_ctx: Context<RecurringTask>) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Terminal task: returns nothing, so a test's assertions are not disturbed by further
     /// rescheduling.
     pub fn noop_task(_ctx: Context<RecurringTask>) -> Result<tuktuk_program::RunTaskReturnV0> {

--- a/solana-programs/programs/return-example/src/lib.rs
+++ b/solana-programs/programs/return-example/src/lib.rs
@@ -67,6 +67,13 @@ pub mod return_example {
         })
     }
 
+    /// Leaves return data behind that is not a task return. Return data is one slot the runtime
+    /// keeps set across nested calls, so a run reads whatever the last call to set it left there,
+    /// which may be a value another program named for its own caller and not a task list at all.
+    pub fn return_non_task_data(_ctx: Context<ReturnNonTaskData>) -> Result<bool> {
+        Ok(false)
+    }
+
     /// Names the tasks account without holding it, so the only place a run could find it is
     /// among the accounts the crank turner appended. A tasks account is the program's to name
     /// out of the accounts its own instruction was given.
@@ -85,6 +92,11 @@ pub mod return_example {
 
 #[derive(Accounts)]
 pub struct ReturnTasksAccountWithoutNamingIt<'info> {
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct ReturnNonTaskData<'info> {
     pub system_program: Program<'info, System>,
 }
 

--- a/solana-programs/programs/return-example/src/lib.rs
+++ b/solana-programs/programs/return-example/src/lib.rs
@@ -67,18 +67,49 @@ pub mod return_example {
         })
     }
 
-    /// Leaves return data behind that is not a task return. Return data is one slot the runtime
-    /// keeps set across nested calls, so a run reads whatever the last call to set it left there,
-    /// which may be a value another program named for its own caller and not a task list at all.
-    pub fn return_non_task_data(_ctx: Context<ReturnNonTaskData>) -> Result<bool> {
+    /// Returns a bool, so the run reads one byte where a task return is at least eight.
+    pub fn return_non_task_data(_ctx: Context<NoAccounts>) -> Result<bool> {
         Ok(false)
+    }
+
+    /// Sets `data` as this program's own return data and returns nothing, so a test names the
+    /// exact bytes a run reads from the program it invoked. Anchor writes a return value after
+    /// the body, so returning unit is what leaves these bytes in place.
+    pub fn set_raw_return_data(_ctx: Context<NoAccounts>, data: Vec<u8>) -> Result<()> {
+        anchor_lang::solana_program::program::set_return_data(&data);
+
+        Ok(())
+    }
+
+    /// Invokes `target` with `data` and then returns nothing of its own, so the return-data slot
+    /// the run reads holds whatever that call left there rather than a value this program named.
+    pub fn call_then_return_nothing(
+        ctx: Context<CallThenReturnNothing>,
+        data: Vec<u8>,
+    ) -> Result<()> {
+        anchor_lang::solana_program::program::invoke(
+            &Instruction {
+                program_id: ctx.accounts.target.key(),
+                accounts: vec![AccountMeta::new_readonly(
+                    ctx.accounts.system_program.key(),
+                    false,
+                )],
+                data,
+            },
+            &[
+                ctx.accounts.system_program.to_account_info(),
+                ctx.accounts.target.to_account_info(),
+            ],
+        )?;
+
+        Ok(())
     }
 
     /// Names the tasks account without holding it, so the only place a run could find it is
     /// among the accounts the crank turner appended. A tasks account is the program's to name
     /// out of the accounts its own instruction was given.
     pub fn return_tasks_account_without_naming_it(
-        _ctx: Context<ReturnTasksAccountWithoutNamingIt>,
+        _ctx: Context<NoAccounts>,
     ) -> Result<RunTaskReturnV0> {
         let (task_return_account, _) =
             Pubkey::find_program_address(&[b"task_return_account"], &crate::ID);
@@ -90,14 +121,17 @@ pub mod return_example {
     }
 }
 
+/// A context for the instructions that name no account of their own.
 #[derive(Accounts)]
-pub struct ReturnTasksAccountWithoutNamingIt<'info> {
+pub struct NoAccounts<'info> {
     pub system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]
-pub struct ReturnNonTaskData<'info> {
+pub struct CallThenReturnNothing<'info> {
     pub system_program: Program<'info, System>,
+    /// CHECK: the program to invoke, named by the caller
+    pub target: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]

--- a/solana-programs/programs/tuktuk/Cargo.toml
+++ b/solana-programs/programs/tuktuk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuktuk"
-version = "0.2.9"
+version = "0.2.10"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -319,8 +319,10 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             if return_program_id == *program_id {
                 let returned = RunTaskReturnV0::try_from_slice(&return_data)
                     .inspect_err(|e| msg!("Return data could not be read: {:?}", e))?;
-                self.process_return_data(&return_program_id, returned, named)
+                self.process_return_data(program_id, returned, named)
                     .inspect_err(|e| msg!("Error processing return data: {:?}", e))?;
+            } else {
+                msg!("Return data was set by a program other than the one invoked; ignored");
             }
         }
 
@@ -419,12 +421,10 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         // Take the id before the account. Ids and free-task accounts are consumed one per created
         // task and their counts are equal, so an exhausted id list is what says there is no
         // account left to take either.
-        let task_id = match self.free_task_ids.pop() {
-            Some(id) => id,
-            None => {
-                return Err(error!(ErrorCode::TooManyReturnedTasks));
-            }
-        };
+        let task_id = self
+            .free_task_ids
+            .pop()
+            .ok_or_else(|| error!(ErrorCode::TooManyReturnedTasks))?;
 
         // `handler` requires the account count to equal the named accounts plus the free task ids,
         // and a task is created only after an id has been taken, so this index names one of the

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -321,10 +321,18 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             // Only the accounts the instruction itself named. The free tasks appended above are
             // the crank turner's to choose, and a tasks account is the program's to name.
             let named = &accounts[..ix.accounts.len()];
-            // A run that cannot place a child it was handed fails, whoever caused it: the
-            // alternative is a task that reports success while the work it returned is gone.
-            self.process_return_data(&return_program_id, &return_data, named)
-                .inspect_err(|e| msg!("Error processing return data: {:?}", e))?;
+            // Return data is one slot the runtime leaves set across nested calls, so what sits
+            // here may have been set by a call the invoked instruction made rather than named
+            // for this program. Bytes that are not a task return named no children and are
+            // skipped. Once they parse, a child that cannot be placed fails the run, whoever
+            // caused it: the alternative is a task that reports success while the work it
+            // returned is gone.
+            match RunTaskReturnV0::deserialize(&mut &return_data[..]) {
+                Ok(returned) => self
+                    .process_return_data(&return_program_id, returned, named)
+                    .inspect_err(|e| msg!("Error processing return data: {:?}", e))?,
+                Err(e) => msg!("Return data is not a task return, skipping: {:?}", e),
+            }
         }
 
         Ok(())
@@ -333,11 +341,9 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
     fn process_return_data(
         &mut self,
         return_program_id: &Pubkey,
-        return_data: &[u8],
+        queue_task_return: RunTaskReturnV0,
         accounts: &[AccountInfo<'info>],
     ) -> Result<()> {
-        let queue_task_return = RunTaskReturnV0::deserialize(&mut &return_data[..])?;
-
         let mut accounts_set = queue_task_return
             .tasks_accounts
             .into_iter()

--- a/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
+++ b/solana-programs/programs/tuktuk/src/instructions/run_task_v0.rs
@@ -175,17 +175,6 @@ struct TaskProcessor<'a, 'info> {
     // Changes to make to task queue
     tasks_to_set: Vec<u16>, // Task IDs to set as existing
     queue_lamports_needed: u64,
-    // Set when a returned task could not be created because of the free-task id or account the
-    // crank turner supplied. Errors raised while processing return data are swallowed, so this
-    // is carried out to `handler` and failed there. The turner picks both, and a task's children
-    // must not be droppable by picking them badly; a reward or description the returning program
-    // chose is that program's fault and is still dropped silently.
-    //
-    // A shortfall of ids also fails the run when the turner supplied every id the task declared
-    // and the returning program asked for more children than that. The run failing leaves the
-    // task queued rather than losing a child, which for a recurring task is its own next run, so
-    // the loud outcome is the one that can be diagnosed.
-    bad_free_task_input: bool,
 }
 
 impl<'a, 'info> TaskProcessor<'a, 'info> {
@@ -233,7 +222,6 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             capacity,
             tasks_to_set: Vec::new(),
             queue_lamports_needed: 0,
-            bad_free_task_input: false,
         })
     }
 
@@ -321,17 +309,18 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
             // Only the accounts the instruction itself named. The free tasks appended above are
             // the crank turner's to choose, and a tasks account is the program's to name.
             let named = &accounts[..ix.accounts.len()];
-            // Return data is one slot the runtime leaves set across nested calls, so what sits
-            // here may have been set by a call the invoked instruction made rather than named
-            // for this program. Bytes that are not a task return named no children and are
-            // skipped. Once they parse, a child that cannot be placed fails the run, whoever
-            // caused it: the alternative is a task that reports success while the work it
-            // returned is gone.
-            match RunTaskReturnV0::deserialize(&mut &return_data[..]) {
-                Ok(returned) => self
-                    .process_return_data(&return_program_id, returned, named)
-                    .inspect_err(|e| msg!("Error processing return data: {:?}", e))?,
-                Err(e) => msg!("Return data is not a task return, skipping: {:?}", e),
+            // Return data is one slot, and the runtime attributes it to whichever program last
+            // set it. A call the invoked instruction made can therefore leave a value here that
+            // was named for its own caller, and a run has no claim on it: children come only
+            // from the program the run invoked. Read strictly, so a task list is exact rather
+            // than a prefix of some other program's bytes, and fail the run when the program's
+            // own return cannot be read or a child it named cannot be placed. The alternative
+            // is a task that reports success while the work it returned is gone.
+            if return_program_id == *program_id {
+                let returned = RunTaskReturnV0::try_from_slice(&return_data)
+                    .inspect_err(|e| msg!("Return data could not be read: {:?}", e))?;
+                self.process_return_data(&return_program_id, returned, named)
+                    .inspect_err(|e| msg!("Error processing return data: {:?}", e))?;
             }
         }
 
@@ -433,7 +422,6 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         let task_id = match self.free_task_ids.pop() {
             Some(id) => id,
             None => {
-                self.bad_free_task_input = true;
                 return Err(error!(ErrorCode::TooManyReturnedTasks));
             }
         };
@@ -447,14 +435,12 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
 
         // Verify the account is empty
         if !free_task_account.data_is_empty() {
-            self.bad_free_task_input = true;
             return Err(error!(ErrorCode::FreeTaskAccountNotEmpty));
         }
 
         let seeds = [b"task", task_queue_key.as_ref(), &task_id.to_le_bytes()];
         let (key, bump_seed) = Pubkey::find_program_address(&seeds, self.ctx.program_id);
         if key != free_task_account.key() {
-            self.bad_free_task_input = true;
             return Err(error!(ErrorCode::InvalidTaskPDA));
         }
 
@@ -526,10 +512,6 @@ impl<'a, 'info> TaskProcessor<'a, 'info> {
         self.tasks_to_set.push(task_data.id);
 
         Ok(())
-    }
-
-    fn had_bad_free_task_input(&self) -> bool {
-        self.bad_free_task_input
     }
 
     fn get_tasks_to_set(&self) -> &[u16] {
@@ -721,12 +703,6 @@ pub fn handler<'info>(
         for ix in &transaction.instructions {
             processor.process_instruction(ix, remaining_accounts)?;
         }
-
-        // A child that failed on the turner's own id or account choice is not one they may drop.
-        require!(
-            !processor.had_bad_free_task_input(),
-            ErrorCode::InvalidTaskPDA
-        );
 
         // Get the changes we need to make
         let tasks_to_set = processor.get_tasks_to_set().to_vec();


### PR DESCRIPTION
Return data is one slot, and the runtime attributes it to whichever program last set it. A call
the invoked instruction makes therefore leaves a value there that was named for its own caller,
and a run has no claim on it: children come only from the program the run invoked.

`count_proxy_vote_v0` is that shape in production. It returns nothing itself but calls the proposal
program, whose vote hook leaves a byte behind, so reading the slot unconditionally failed every
proxy's delegated vote once such a read became fatal. On mainnet no proxy's delegated power has
landed on the open HIP-150 proposal, about 30% of total voting power, and the largest proxy has
four `proxy vote` tasks queued and retrying against the same failure.

## Measured, not inferred

The `Program return:` lines in a transaction log are emitted per frame exit with the finishing
program's id, which reads as though the invoked program set the data. `get_return_data()` reports
the setter. Instrumenting the program and replaying a queued mainnet task on a fork:

```
return_program_id=stcfiqW3…(state controller)  invoked=hvsrNC3…(voter-stake registry)  len=1
return_program_id=hcrLPFg…                     invoked=hcrLPFg…                        len=283
return_program_id=hcrLPFg…                     invoked=hcrLPFg…                        len=217
```

The hook's byte is attributed to a program the run did not invoke; both legitimate task returns in
the same transaction are attributed to the program that was invoked. Comparing the two separates
the cases exactly.

The program's own return is now read with `try_from_slice` rather than `deserialize`, so a task
list is the whole value rather than a prefix of another program's bytes. An unreadable return, or
a child that cannot be placed, still fails the run.

## Why it started

`process_return_data` has always been unable to parse this return data. Its error was logged and
swallowed until #103 changed it to `?`, and the program was upgraded on mainnet the following day.
HIP-150 is the first proposal to open since. A pre-upgrade run that succeeded carries the identical
log line and goes on to requeue and pay the crank reward
(`4mjcrz36s8EEKNXKJGGEK1Nff1QbfKxzrvxh4eq4K1tuaxs9aGFDZX7rg9MoABMVRi47VhMPQ9fno1yMW1mrXi3C`).

## Verification

Replayed on a mainnet fork with a real queued task and the vote service's real response. Live
program: `BorshIoError`, run fails. This build: `err: null`, the counted weight lands on the
proposal, the spent task is consumed, and two children are placed including the next `proxy vote`
task, so the requeue chain continues.

Four mutations, each caught by the test that names it, totals back at the 21-test baseline:

| mutation | caught by |
|---|---|
| drop the setter comparison | `a_nested_calls_return_data_is_not_read_as_a_task_return`, `a_nested_calls_task_return_is_not_queued` |
| `try_from_slice` → `deserialize` | `a_task_return_followed_by_trailing_bytes_fails_the_run` |
| placement failure non-fatal | `a_returned_reward_above_the_queue_minimum_fails_the_run`, `a_free_task_account_that_does_not_match_its_id_fails_the_run` |
| free-task PDA check permissive | `a_free_task_account_that_does_not_match_its_id_fails_the_run` |

`bad_free_task_input` is removed: every site that set it also returned an error, and those
propagate, so `handler`'s `require!` on the flag could never be what failed a run. Its comment
claimed those errors were swallowed.

Version moves to 0.2.10, since 0.2.9 is released and on-chain behaviour changes here.
