### PR TITLE
Adopt a cron chain whose record is the default pubkey

### DIFF
--- a/solana-programs/Cargo.lock
+++ b/solana-programs/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "cron"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana-programs/programs/cron/Cargo.toml
+++ b/solana-programs/programs/cron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cron"
-version = "0.3.1"
+version = "0.3.2"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana-programs/programs/cron/src/instructions/queue_cron_tasks_v1.rs
+++ b/solana-programs/programs/cron/src/instructions/queue_cron_tasks_v1.rs
@@ -82,7 +82,14 @@ pub fn handler(ctx: Context<QueueCronTasksV1>) -> Result<RunTaskReturnV0> {
     // does not depend on the run being one this program can identify. Reading the running task
     // needs `run_task_v0` to be the top-level instruction, which a caller that reaches it through
     // its own CPI does not give.
-    if !ctx.accounts.recorded_schedule_task.data_is_empty() {
+    //
+    // A record holds nothing in two spellings: the account is empty, or the record is
+    // `Pubkey::default()`. The default is the system program, which has data, so the emptiness
+    // test alone reads it as live and refuses the adoption this allows — the same reason
+    // `requeue_cron_task_v1` spells its default arm out.
+    let record_holds_a_task = cron_job.next_schedule_task != Pubkey::default()
+        && !ctx.accounts.recorded_schedule_task.data_is_empty();
+    if record_holds_a_task {
         require!(
             running_schedule_task(&ctx.accounts.sysvar_instructions)?
                 == cron_job.next_schedule_task,

--- a/solana-programs/programs/cron/src/instructions/queue_cron_tasks_v1.rs
+++ b/solana-programs/programs/cron/src/instructions/queue_cron_tasks_v1.rs
@@ -83,10 +83,9 @@ pub fn handler(ctx: Context<QueueCronTasksV1>) -> Result<RunTaskReturnV0> {
     // needs `run_task_v0` to be the top-level instruction, which a caller that reaches it through
     // its own CPI does not give.
     //
-    // A record holds nothing in two spellings: the account is empty, or the record is
-    // `Pubkey::default()`. The default is the system program, which has data, so the emptiness
-    // test alone reads it as live and refuses the adoption this allows — the same reason
-    // `requeue_cron_task_v1` spells its default arm out.
+    // A record holds nothing when it is `Pubkey::default()` or its account is empty. The default
+    // is the system program, which has data, so the emptiness test alone does not answer it —
+    // `requeue_cron_task_v1` spells the same arm out.
     let record_holds_a_task = cron_job.next_schedule_task != Pubkey::default()
         && !ctx.accounts.recorded_schedule_task.data_is_empty();
     if record_holds_a_task {
@@ -284,8 +283,9 @@ pub fn handler(ctx: Context<QueueCronTasksV1>) -> Result<RunTaskReturnV0> {
     }
 }
 
-/// The cron job cannot fund what this run would queue, so it leaves the queue and waits for a
-/// requeue. Clearing `next_schedule_task` is what lets the requeue adopt the chain.
+/// The cron job cannot fund what this run would queue, so it leaves the queue. Clearing
+/// `next_schedule_task` is what leaves the record holding nothing, which is the state a requeue
+/// and an adopting schedule run both answer to.
 fn stand_down(cron_job: &mut Account<CronJobV0>) -> Result<RunTaskReturnV0> {
     msg!(
         "Not enough lamports to fund tasks. Please requeue cron job when you have enough lamports. {}",

--- a/solana-programs/programs/cron/src/state.rs
+++ b/solana-programs/programs/cron/src/state.rs
@@ -29,7 +29,8 @@ pub struct CronJobV0 {
     pub next_transaction_id: u32,
     // Deprecated: You should use the next_schedule_task instead
     // A cron job is removed from the queue when it no longer has enough lamports to fund tasks
-    // Once this is set, you need to requeue the cron job.
+    // Once this is set, the record holds nothing, which is the state a requeue and an adopting
+    // schedule run both answer to.
     pub removed_from_queue: bool,
     pub bump_seed: u8,
     // Pubkey::default() when no task scheduled

--- a/solana-programs/tests/cron.ts
+++ b/solana-programs/tests/cron.ts
@@ -1039,6 +1039,81 @@ describe("cron", () => {
         expectUnchanged(before, await snapshot(keys), keys);
       });
 
+      it("adopts a chain whose record a stand-down cleared to the default", async () => {
+        // A stand-down clears the record to `Pubkey::default()`, which is the system program and
+        // so has data. A schedule task still queued from before it adopts that vacancy, the same
+        // as it adopts a record account that is empty.
+        const { job: poor, taskId } = await createCronJobFor(makeid(10), 0);
+        await addCronTransaction(poor, 0);
+        await run(taskKey(taskQueue, taskId)[0], [90, 91]);
+
+        const stood_down = await cronProgram.account.cronJobV0.fetch(poor);
+        expect(
+          stood_down.nextScheduleTask.toBase58(),
+          "precondition: the record is the default"
+        ).to.eq(PublicKey.default.toBase58());
+
+        // Funded so that what the adoption then queues is not what fails.
+        await sendInstructions(provider, [
+          SystemProgram.transfer({
+            fromPubkey: me,
+            toPubkey: poor,
+            lamports: 10000000000,
+          }),
+        ]);
+
+        const [cronSigner, bump] = customSignerKey(taskQueue, [
+          Buffer.from("cron"),
+          poor.toBuffer(),
+        ]);
+        const ix = await cronProgram.methods
+          .queueCronTasksV1()
+          .accountsPartial({
+            cronJob: poor,
+            taskQueue,
+            cronSigner,
+            recordedScheduleTask: PublicKey.default,
+          })
+          .remainingAccounts([
+            {
+              pubkey: cronJobTransactionKey(poor, 0)[0],
+              isSigner: false,
+              isWritable: false,
+            },
+          ])
+          .instruction();
+        const bumpBuffer = Buffer.alloc(1);
+        bumpBuffer.writeUint8(bump);
+        const compiled = compileTransaction(
+          [ix],
+          [[Buffer.from("cron"), poor.toBuffer(), bumpBuffer]]
+        );
+        const adoptTask = taskKey(taskQueue, 9)[0];
+        await tuktukProgram.methods
+          .queueTaskV0({
+            id: 9,
+            trigger: { now: {} },
+            transaction: { compiledV0: [compiled.transaction] },
+            crankReward: null,
+            freeTasks: numTasksPerQueueCall + 1,
+            description: "adopt ended",
+          })
+          .remainingAccounts(compiled.remainingAccounts)
+          .accounts({ payer: me, taskQueue, task: adoptTask })
+          .rpc({ skipPreflight: true });
+
+        await run(adoptTask, [92, 93]);
+
+        const adopted = await cronProgram.account.cronJobV0.fetch(poor);
+        expect(
+          adopted.nextScheduleTask.toBase58(),
+          "the adopting run records its own successor"
+        ).to.eq(taskKey(taskQueue, 92)[0].toBase58());
+        isV1Schedule(
+          await tuktukProgram.account.taskV0.fetch(taskKey(taskQueue, 92)[0])
+        );
+      });
+
       it("refuses a schedule run that queues another cron job's transactions", async () => {
         // A record says which job it belongs to in its contents, and a schedule run queues
         // only the records belonging to the job whose funds pay for them.

--- a/solana-programs/tests/cron.ts
+++ b/solana-programs/tests/cron.ts
@@ -1039,21 +1039,23 @@ describe("cron", () => {
         expectUnchanged(before, await snapshot(keys), keys);
       });
 
-      it("adopts a chain whose record a stand-down cleared to the default", async () => {
-        // A stand-down clears the record to `Pubkey::default()`, which is the system program and
-        // so has data. A schedule task still queued from before it adopts that vacancy, the same
-        // as it adopts a record account that is empty.
+      it("adopts a chain a legacy handover named the default", async () => {
+        // `queue_cron_tasks_v0` reads `next_schedule_task` when it runs, so it is the one
+        // compiler that can name `Pubkey::default()` in the successor it hands over -- every
+        // other names the successor's own key. Running one against a job that has already stood
+        // down is therefore what produces a schedule task pointed at a record holding nothing.
         const { job: poor, taskId } = await createCronJobFor(makeid(10), 0);
         await addCronTransaction(poor, 0);
-        await run(taskKey(taskQueue, taskId)[0], [90, 91]);
 
+        // Stand it down: it cannot fund the tasks its own chain owes.
+        await run(taskKey(taskQueue, taskId)[0], [90, 91]);
         const stood_down = await cronProgram.account.cronJobV0.fetch(poor);
         expect(
           stood_down.nextScheduleTask.toBase58(),
-          "precondition: the record is the default"
+          "precondition: the stand-down left the record at the default"
         ).to.eq(PublicKey.default.toBase58());
 
-        // Funded so that what the adoption then queues is not what fails.
+        // Funded, so what the adoption queues is not what fails.
         await sendInstructions(provider, [
           SystemProgram.transfer({
             fromPubkey: me,
@@ -1062,55 +1064,39 @@ describe("cron", () => {
           }),
         ]);
 
-        const [cronSigner, bump] = customSignerKey(taskQueue, [
-          Buffer.from("cron"),
-          poor.toBuffer(),
-        ]);
-        const ix = await cronProgram.methods
-          .queueCronTasksV1()
-          .accountsPartial({
-            cronJob: poor,
-            taskQueue,
-            cronSigner,
-            recordedScheduleTask: PublicKey.default,
-          })
-          .remainingAccounts([
-            {
-              pubkey: cronJobTransactionKey(poor, 0)[0],
-              isSigner: false,
-              isWritable: false,
-            },
-          ])
-          .instruction();
-        const bumpBuffer = Buffer.alloc(1);
-        bumpBuffer.writeUint8(bump);
-        const compiled = compileTransaction(
-          [ix],
-          [[Buffer.from("cron"), poor.toBuffer(), bumpBuffer]]
-        );
-        const adoptTask = taskKey(taskQueue, 9)[0];
+        // A legacy v0 task, of the kind still queued from before the handover.
+        const legacy = compileTransaction([legacyScheduleIx(poor)], []);
+        const legacyTask = taskKey(taskQueue, 9)[0];
         await tuktukProgram.methods
           .queueTaskV0({
             id: 9,
             trigger: { now: {} },
-            transaction: { compiledV0: [compiled.transaction] },
+            transaction: { compiledV0: [legacy.transaction] },
             crankReward: null,
             freeTasks: numTasksPerQueueCall + 1,
-            description: "adopt ended",
+            description: "legacy handover",
           })
-          .remainingAccounts(compiled.remainingAccounts)
-          .accounts({ payer: me, taskQueue, task: adoptTask })
+          .remainingAccounts(legacy.remainingAccounts)
+          .accounts({ payer: me, taskQueue, task: legacyTask })
           .rpc({ skipPreflight: true });
 
-        await run(adoptTask, [92, 93]);
+        // It hands over a v1 schedule task, and names the default because that is what the
+        // stood-down job records.
+        await run(legacyTask, [92, 93]);
+        const handedOver = taskKey(taskQueue, 92)[0];
+        isV1Schedule(await tuktukProgram.account.taskV0.fetch(handedOver));
+
+        // Running that successor is the adoption.
+        await run(handedOver, [94, 95]);
 
         const adopted = await cronProgram.account.cronJobV0.fetch(poor);
         expect(
           adopted.nextScheduleTask.toBase58(),
           "the adopting run records its own successor"
-        ).to.eq(taskKey(taskQueue, 92)[0].toBase58());
+        ).to.eq(taskKey(taskQueue, 94)[0].toBase58());
+        expect(adopted.removedFromQueue, "back in the queue").to.be.false;
         isV1Schedule(
-          await tuktukProgram.account.taskV0.fetch(taskKey(taskQueue, 92)[0])
+          await tuktukProgram.account.taskV0.fetch(taskKey(taskQueue, 94)[0])
         );
       });
 


### PR DESCRIPTION
A cron job records the one task carrying its schedule, and a run either is that task or adopts a
record that holds nothing. A record holds nothing in two spellings: the account is empty, or the
record is `Pubkey::default()`.

The default pubkey is the system program, which has data, so `data_is_empty()` alone read it as a
live record and refused the adoption. `requeue_cron_task_v1` already names the default explicitly:

```rust
constraint = cron_job.next_schedule_task == Pubkey::default()
    || next_schedule_task.data_is_empty() @ ErrorCode::TaskAlreadyQueued,
```

`queue_cron_tasks_v1` now reads the same way.

## Which predecessor this reaches

`queue_cron_tasks_v0` reads `next_schedule_task` when it runs, so it is the only compiler that can
name `Pubkey::default()` in the successor it hands over — `initialize_cron_job_v0`,
`requeue_cron_task_v1` and `queue_cron_tasks_v1` all name the successor's own key, which fails the
unchanged `require_keys_eq!` long before this line. So the case is a legacy v0 handover running
against a job that has already stood down.

## What it widens, deliberately

`requeue_cron_task_v1` is gated on the job's `authority`. Adoption is not: it is reachable by
anyone who can place a task on the job's task queue. So a job whose record is at the default can
now be restarted by a party other than its owner, which clears `removed_from_queue` and spends the
job's lamports on its own scheduled records.

This is the same authorization the empty-record arm has always had, and it cannot strand a job:
the successor is compiled by this program rather than by the caller, a failed adoption commits
nothing, the too-early branch returns before any mutation, `stand_down` returns to the same
recoverable state, and an ended chain empties the record so the owner's requeue reopens. Adoption
is capped per schedule period by the `now + QUEUE_TASK_DELAY < current_exec_ts` gate and the
`current_transaction_id` advance, so it queues no more than the schedule itself would.

One consequence worth naming: an adoption resumes the cycle where a requeue resets it, so a
stand-down part-way through an execution is followed by the remaining records rather than a whole
one. Only jobs with `num_tasks_per_queue_call > 1` can be part-way through.

## Verification

`tests/cron.ts` gains a case that stands a job down, funds it, runs a legacy v0 task against it,
and runs the successor that hands over — asserting the chain resumes and `removedFromQueue` is
cleared. 18 passing.

Mutation-tested: dropping the default arm back to the bare emptiness test reddens that case and
only that case, 17 passing + 1 failing against the 18-test baseline, restored byte-identical after.

Version moves to 0.3.2, since 0.3.1 is released and on-chain behaviour changes here.
