### PR TITLE
Bring cron's tuktuk-program pin up to the workspace

### DIFF
--- a/program-tests/Cargo.lock
+++ b/program-tests/Cargo.lock
@@ -5338,8 +5338,8 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-program"
-version = "0.3.0"
-source = "git+https://github.com/helium/tuktuk.git?rev=112afe5e80aff8199c3b779203b76b35d97c42d1#112afe5e80aff8199c3b779203b76b35d97c42d1"
+version = "0.4.0"
+source = "git+https://github.com/helium/tuktuk.git?rev=2d19afd2b5ed2ea09649e231059d5bb434dd5453#2d19afd2b5ed2ea09649e231059d5bb434dd5453"
 dependencies = [
  "anchor-lang",
 ]

--- a/solana-programs/Cargo.lock
+++ b/solana-programs/Cargo.lock
@@ -2776,8 +2776,8 @@ dependencies = [
 
 [[package]]
 name = "tuktuk-program"
-version = "0.3.0"
-source = "git+https://github.com/helium/tuktuk.git?rev=112afe5e80aff8199c3b779203b76b35d97c42d1#112afe5e80aff8199c3b779203b76b35d97c42d1"
+version = "0.4.0"
+source = "git+https://github.com/helium/tuktuk.git?rev=2d19afd2b5ed2ea09649e231059d5bb434dd5453#2d19afd2b5ed2ea09649e231059d5bb434dd5453"
 dependencies = [
  "anchor-lang",
 ]

--- a/solana-programs/programs/cpi-example/Cargo.toml
+++ b/solana-programs/programs/cpi-example/Cargo.toml
@@ -26,6 +26,6 @@ anchor-spl = { workspace = true, features = ["token"] }
 solana-zk-sdk = { workspace = true }
 # tuktuk-program = { path = "../../../tuktuk-program" }
 # Need to use this for build-verify to work. Use above for debug before pushing
-tuktuk-program = { git = "https://github.com/helium/tuktuk.git", rev = "112afe5e80aff8199c3b779203b76b35d97c42d1" }
+tuktuk-program = { git = "https://github.com/helium/tuktuk.git", rev = "2d19afd2b5ed2ea09649e231059d5bb434dd5453" }
 getrandom = { version = "0.2.15", features = ["custom"] }
 

--- a/solana-programs/programs/cron/Cargo.toml
+++ b/solana-programs/programs/cron/Cargo.toml
@@ -27,7 +27,7 @@ solana-zk-sdk = { workspace = true }
 
 # tuktuk-program = { path = "../../../tuktuk-program" }
 # Need to use this for build-verify to work. Use above for debug before pushing
-tuktuk-program = { git = "https://github.com/helium/tuktuk.git", rev = "112afe5e80aff8199c3b779203b76b35d97c42d1" }
+tuktuk-program = { git = "https://github.com/helium/tuktuk.git", rev = "2d19afd2b5ed2ea09649e231059d5bb434dd5453" }
 clockwork-cron = "2.0.19"
 chrono = "0.4.39"
 

--- a/solana-programs/programs/return-example/Cargo.toml
+++ b/solana-programs/programs/return-example/Cargo.toml
@@ -25,5 +25,5 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-lang = { workspace = true }
 # tuktuk-program = { path = "../../../tuktuk-program" }
 # Need to use this for build-verify to work. Use above for debug before pushing
-tuktuk-program = { git = "https://github.com/helium/tuktuk.git", rev = "112afe5e80aff8199c3b779203b76b35d97c42d1" }
+tuktuk-program = { git = "https://github.com/helium/tuktuk.git", rev = "2d19afd2b5ed2ea09649e231059d5bb434dd5453" }
 getrandom = { version = "0.2.15", features = ["custom"] }


### PR DESCRIPTION
`cron` pins `tuktuk-program` to a rev from 2025-03-16, 15 commits behind on that crate. The
resolved copy predates two fixes this repo already carries:

- `write_return_tasks` ends its outer loop with `if num_tasks == 0 || tasks.next().is_none()`,
  which advances the iterator to test it. Once the inner loop has broken because a return account
  filled, the task that call consumes is neither written nor counted, so `total_tasks` undercounts
  and one returned task is lost. The rev this moves to answers the same question from a flag.
- `next_available_task_id` can offer an id out of the bits a bitmap's last byte holds past
  capacity. The rev this moves to bounds it.

## Neither is reachable from cron today

Measured, not inferred:

| Bound | Value | Set by |
|---|---|---|
| A stored record's transaction | ~900 bytes | `add_cron_transaction_v0` is itself a transaction; 950b fails with `Transaction too large: 1259 > 1232` |
| Records per run | 5 | `MAX_TASKS_PER_QUEUE_CALL` |
| Returned payload per run | ~6KB | the two above |
| Moves the write to a second account | 10240 bytes | `MAX_PERMITTED_DATA_INCREASE` |

So the overflow path is about 60% of the way to being reachable, with both caps hard. And the one
live queue's capacity is a multiple of eight, so its bitmap carries no bits past capacity.

Both arm themselves if either cap moves, which is the reason to take the fixes now rather than
when something raises one.

## No version bump

Behaviour is unchanged, so `cron` stays at its current version and this rides to mainnet with the
next cron deploy rather than asking for one of its own.

The two example programs move with it to keep a single rev across the workspace.

Suites green against the new pin: fmt, clippy `-D warnings`, `cargo test --lib`, program-tests
23/23, `tests/cron.ts` 18, `tests/tuktuk.ts` 22.
